### PR TITLE
Revise `ScriptProcessor` logic

### DIFF
--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -77,6 +77,32 @@ const PlatformURL: {
   },
 }
 
+/**
+ * Opcode constants
+ */
+const opcodes = {
+  OP_RETURN: 0x6a,
+  OP_PUSHDATA1: 0x4c,
+  // RANK sentiments
+  OP_0: 0x00, // negative
+  OP_1: 0x51, // positive
+  OP_2: 0x52,
+  OP_3: 0x53,
+  OP_4: 0x54,
+  OP_5: 0x55,
+  OP_6: 0x56,
+  OP_7: 0x57,
+  OP_8: 0x58,
+  OP_9: 0x59,
+  OP_10: 0x5a,
+  OP_11: 0x5b,
+  OP_12: 0x5c,
+  OP_13: 0x5d,
+  OP_14: 0x5e,
+  OP_15: 0x5f,
+  OP_16: 0x60, // neutral
+} as const
+
 export {
   // API URLs
   CHRONIK_API_URL,
@@ -95,6 +121,7 @@ export {
   // Lotus constants
   MAX_OP_RETURN_RELAY,
   MAX_OP_RETURN_DATA,
+  opcodes,
   // RANK script configuration
   RANK_OUTPUT_MIN_VALID_SATS,
   RANK_BLOCK_GENESIS_V1,


### PR DESCRIPTION
Each instance of `ScriptProcessor` is meant for one output script. This commit revises the logic to acommodate this. However, since the new RNKC LOKAD protocol requires more than one output script to be valid, an `addScript` method is added to allow higher level applications to supplement the processor with additional `OP_RETURN` scripts where required.

Also, a constant is added for op codes. This object will be filled out as new op codes are supported in the library.