### PR TITLE
Pass `burnedSats` argument to RNKC processor method

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ NODE_RPC_PORT="10604"
 NNG_SUB_SOCKET_PATH="/home/user/.lotus/pub.pipe"
 # NNG req socket sends RPC requests to lotusd
 NNG_REQ_SOCKET_PATH="/home/user/.lotus/rpc.pipe"
+# Minimum satoshi/byte value required for accepting RNKC transactions
+RNKC_MIN_FEE_RATE="10000000" # satoshis
+# Minimum total data length of RNKC comment data
+RNKC_MIN_DATA_LENGTH="1" # bytes

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -54,6 +54,10 @@ export const RANK_BLOCK_GENESIS_V1: Partial<Block> = {
   hash: '0000000000c974cb635064bec0db8cc64a75526871f581ea5dbeca7a98551546',
   height: 952169,
 }
+/** Minimum RNKC burn value in sats */
+export const RNKC_MIN_FEE_RATE = 10_000_000 // minimum RNKC burn value in sats
+/** Minimum RNKC comment length in bytes */
+export const RNKC_MIN_DATA_LENGTH = 1 // minimum RNKC comment length in bytes
 
 /**
  * Dashboard configuration

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -7,6 +7,8 @@ import { config } from 'dotenv'
 import {
   NNG_SUB_SOCKET_PATH_DEFAULT,
   NNG_REQ_SOCKET_PATH_DEFAULT,
+  RNKC_MIN_DATA_LENGTH,
+  RNKC_MIN_FEE_RATE,
 } from '../utils/constants'
 
 const parsed = config({ path: '.env' }).parsed
@@ -25,4 +27,9 @@ export const RPC = {
 export const NNG = {
   subSocketPath: parsed.NNG_SUB_SOCKET_PATH || NNG_SUB_SOCKET_PATH_DEFAULT,
   reqSocketPath: parsed.NNG_REQ_SOCKET_PATH || NNG_REQ_SOCKET_PATH_DEFAULT,
+}
+
+export const RNKC = {
+  minFeeRate: Number(parsed.RNKC_MIN_FEE_RATE) || RNKC_MIN_FEE_RATE,
+  minDataLength: Number(parsed.RNKC_MIN_DATA_LENGTH) || RNKC_MIN_DATA_LENGTH,
 }


### PR DESCRIPTION
This commit adds a new parameter to `processScriptRNKC` in order to calculate the `feeRate` directly within the script processor method. We also hard-code some default constants and add `.env` variables that are parsed into, and exported from, the `settings` module.