### PR TITLE
Add `inReplyToCommentId` to RNKC output type

### DIFF
--- a/lib/rank.ts
+++ b/lib/rank.ts
@@ -77,6 +77,8 @@ export type TransactionOutputRNKC = {
   inReplyToProfileId?: string
   /** ID of the post being replied to */
   inReplyToPostId?: string
+  /** ID of the comment being replied to */
+  inReplyToCommentId?: string
 }
 export type IndexedTransaction = {
   txid: string
@@ -769,6 +771,7 @@ export class ScriptProcessor {
       platform,
       inReplyToProfileId: undefined,
       inReplyToPostId: undefined,
+      inReplyToCommentId: undefined,
     }
 
     // Check profileId (must exist and be valid for the platform)
@@ -778,7 +781,14 @@ export class ScriptProcessor {
       // Check for postId (only valid if profileId is valid)
       const postId = this.processPostId(platform)
       if (postId) {
-        output.inReplyToPostId = postId
+        switch (platform) {
+          case 'lotusia':
+            output.inReplyToCommentId = postId
+            break
+          default:
+            output.inReplyToPostId = postId
+            break
+        }
       }
     }
 


### PR DESCRIPTION
This is necessary in order to differentiate between a RNKC transaction that is replying to another RankComment or an external platform post