### PR TITLE
Add optional `data` property to `Post` type

### DIFF
--- a/lib/rank.ts
+++ b/lib/rank.ts
@@ -117,6 +117,8 @@ export type Profile = RankTarget & {
 /**  */
 export type Post = RankTarget & {
   profileId: string
+  /** The post text, if applicable (decoded from UTF-8) */
+  data?: Uint8Array
   /** The hash of the post content (i.e. RankOutput['postHash']) */
   // hash: string
 }


### PR DESCRIPTION
RNKC transactions are not only comments on existing profiles and posts, but are also posts in themselves. This commit adds the `data` property to the `Post` type so that indexers can set the data in the indexed `Post` objects during SQL statement execution.