### PR TITLE
Do not throw on `ScriptProcessor` instantiation

### DIFF
--- a/lib/rank.ts
+++ b/lib/rank.ts
@@ -535,8 +535,6 @@ export class ScriptProcessor {
       case 'RNKC':
         this.chunks = ScriptChunksRNKCMap
         break
-      default:
-        throw new Error(`Invalid or undefined LOKAD type for script`)
     }
   }
 


### PR DESCRIPTION
This commit adjusts the `ScriptProcessor` constructor to not throw an error if there is no valid LOKAD type in the script. The onus is then on the calling application to check the validity of the script using the `lokadType` getter.