### PR TITLE
Convert package to `commonjs` type

### DIFF
--- a/lib/bitcore/encoding/base58.ts
+++ b/lib/bitcore/encoding/base58.ts
@@ -3,7 +3,9 @@
  * Migrated from bitcore-lib-xpi with ESM support and TypeScript
  */
 
-import bs58 from 'bs58'
+// Need to use the require syntax to load bs58 in cjs
+// eslint-disable-next-line @typescript-eslint/no-require-imports
+const bs58 = require('bs58').default
 
 const ALPHABET =
   '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz'.split('')

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "description": "Central repository for several classes of tools for integrating with, and building for, the Lotusia ecosystem",
   "main": "index.js",
-  "type": "module",
+  "type": "commonjs",
   "directories": {
     "lib": "lib"
   },


### PR DESCRIPTION
This commit is unfortunately necessary because this package needs to integrate into the existing Lotusia infrastructure. Namely, the Temporal automation infrastructure bundles workflows into CommonJS modules. Until this is fixed, `lotus-lib` must be a `commonjs` type.