### PR TITLE
Do not rate limit outselves, allow bypass for testing

### DIFF
--- a/examples/musig2-p2p-election-example.ts
+++ b/examples/musig2-p2p-election-example.ts
@@ -59,6 +59,9 @@ async function setupParticipant(name: string): Promise<Participant> {
       listen: ['/ip4/127.0.0.1/tcp/0'],
       enableDHT: true,
       enableDHTServer: true,
+      securityConfig: {
+        disableRateLimiting: true, // For demo - remove in production
+      },
     },
     {
       enableCoordinatorElection: true,

--- a/examples/musig2-p2p-example.ts
+++ b/examples/musig2-p2p-example.ts
@@ -6,7 +6,7 @@
  */
 
 import { waitForEvent, ConnectionEvent } from '../lib/p2p/index.js'
-import { MuSig2P2PCoordinator } from '../lib/p2p/musig2/index.js'
+import { MuSig2P2PCoordinator, MuSig2Event } from '../lib/p2p/musig2/index.js'
 import { PrivateKey } from '../lib/bitcore/privatekey.js'
 
 /**
@@ -25,12 +25,18 @@ async function main() {
     listen: ['/ip4/127.0.0.1/tcp/0'], // Random port
     enableDHT: true,
     enableDHTServer: true, // Enable DHT server for session discovery
+    securityConfig: {
+      disableRateLimiting: true, // For demo - remove in production
+    },
   })
 
   const bobMuSig = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'], // Random port
     enableDHT: true,
     enableDHTServer: true,
+    securityConfig: {
+      disableRateLimiting: true, // For demo - remove in production
+    },
   })
 
   await aliceMuSig.start()
@@ -67,27 +73,27 @@ async function main() {
   console.log('Step 4: Alice creates and announces session...')
 
   // Listen for session events
-  aliceMuSig.on('session:created', sessionId => {
+  aliceMuSig.on(MuSig2Event.SESSION_CREATED, (sessionId: string) => {
     console.log(`[Alice] Session created: ${sessionId}`)
   })
 
-  aliceMuSig.on('session:nonces-complete', sessionId => {
+  aliceMuSig.on(MuSig2Event.SESSION_NONCES_COMPLETE, (sessionId: string) => {
     console.log(`[Alice] All nonces received for session: ${sessionId}`)
   })
 
-  aliceMuSig.on('session:complete', sessionId => {
+  aliceMuSig.on(MuSig2Event.SESSION_COMPLETE, (sessionId: string) => {
     console.log(`[Alice] Session complete: ${sessionId}`)
   })
 
-  bobMuSig.on('session:joined', sessionId => {
+  bobMuSig.on(MuSig2Event.SESSION_JOINED, (sessionId: string) => {
     console.log(`[Bob] Joined session: ${sessionId}`)
   })
 
-  bobMuSig.on('session:nonces-complete', sessionId => {
+  bobMuSig.on(MuSig2Event.SESSION_NONCES_COMPLETE, (sessionId: string) => {
     console.log(`[Bob] All nonces received for session: ${sessionId}`)
   })
 
-  bobMuSig.on('session:complete', sessionId => {
+  bobMuSig.on(MuSig2Event.SESSION_COMPLETE, (sessionId: string) => {
     console.log(`[Bob] Session complete: ${sessionId}`)
   })
 

--- a/examples/musig2-p2p-taproot-example.ts
+++ b/examples/musig2-p2p-taproot-example.ts
@@ -65,12 +65,18 @@ async function main() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true,
+    securityConfig: {
+      disableRateLimiting: true, // For demo - remove in production
+    },
   })
 
   const bobMuSig = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true,
+    securityConfig: {
+      disableRateLimiting: true, // For demo - remove in production
+    },
   })
 
   await aliceMuSig.start()

--- a/examples/musig2-three-phase-example.ts
+++ b/examples/musig2-three-phase-example.ts
@@ -33,18 +33,29 @@ async function threePhaseExample() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
+    securityConfig: {
+      // Note: In production, remove disableRateLimiting for security
+      // This is only for demo purposes to allow rapid advertisements
+      disableRateLimiting: true,
+    },
   })
 
   const bobCoordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
+    securityConfig: {
+      disableRateLimiting: true,
+    },
   })
 
   const charlieCoordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
+    securityConfig: {
+      disableRateLimiting: true,
+    },
   })
 
   // Start all coordinators
@@ -312,6 +323,9 @@ async function advertisementExample() {
   const coordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   await coordinator.start()
@@ -400,6 +414,9 @@ async function matchmakingDHTExample() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true, // Zoe is a full DHT server
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   await zoeCoordinator.start()
@@ -429,6 +446,9 @@ async function matchmakingDHTExample() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true, // Bob participates in DHT routing
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   // Charlie runs a signing service
@@ -436,6 +456,9 @@ async function matchmakingDHTExample() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true, // Charlie participates in DHT routing
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   await Promise.all([bobCoordinator.start(), charlieCoordinator.start()])
@@ -560,6 +583,9 @@ async function matchmakingDHTExample() {
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false, // Alice is a client, not a DHT server
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   await aliceCoordinator.start()
@@ -1189,6 +1215,9 @@ async function eventDrivenExample() {
   const coordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
   })
 
   await coordinator.start()

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -149,6 +149,24 @@ export interface P2PConfig {
   enableGossipSub?: boolean
 
   /**
+   * Security configuration
+   * Use for testing or custom security requirements
+   */
+  securityConfig?: {
+    /**
+     * Disable rate limiting (TESTING ONLY)
+     * WARNING: Never use in production - removes DoS protection
+     * Default: false
+     */
+    disableRateLimiting?: boolean
+
+    /**
+     * Custom security limits (override defaults)
+     */
+    customLimits?: Partial<typeof CORE_P2P_SECURITY_LIMITS>
+  }
+
+  /**
    * DHT peer info mapper function
    * Controls which peer addresses are considered valid for DHT operations.
    *

--- a/test/p2p/musig2/coordinator.test.ts
+++ b/test/p2p/musig2/coordinator.test.ts
@@ -17,6 +17,9 @@ describe('MuSig2 P2P Coordinator', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true, // Disable for tests
+        },
       })
 
       await musig2Coordinator.start()
@@ -36,6 +39,9 @@ describe('MuSig2 P2P Coordinator', () => {
           listen: ['/ip4/127.0.0.1/tcp/0'],
           enableDHT: true,
           enableDHTServer: false,
+          securityConfig: {
+            disableRateLimiting: true, // Disable for tests
+          },
         },
         {
           sessionTimeout: timeout,
@@ -55,6 +61,9 @@ describe('MuSig2 P2P Coordinator', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true, // Disable for tests
+        },
       })
 
       await musig2Coordinator.start()
@@ -76,6 +85,9 @@ describe('MuSig2 P2P Coordinator', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true, // Disable for tests
+        },
       })
 
       await musig2Coordinator.start()
@@ -204,6 +216,9 @@ describe('MuSig2 P2P Coordinator', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true, // Disable for tests
+        },
       })
 
       await musig2Coordinator.start()

--- a/test/p2p/musig2/integration.test.ts
+++ b/test/p2p/musig2/integration.test.ts
@@ -46,12 +46,18 @@ describe('MuSig2 P2P Integration', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobMuSig = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await aliceMuSig.start()
@@ -191,18 +197,27 @@ describe('MuSig2 P2P Integration', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobMuSig = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       carolMuSig = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await aliceMuSig.start()
@@ -286,6 +301,9 @@ describe('MuSig2 P2P Integration', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await aliceMuSig.start()
@@ -311,6 +329,9 @@ describe('MuSig2 P2P Integration', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await bobMuSig.start()

--- a/test/p2p/musig2/protocol-handler.test.ts
+++ b/test/p2p/musig2/protocol-handler.test.ts
@@ -35,6 +35,9 @@ describe('MuSig2 P2P Protocol Handler', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await musig2Coordinator.start()
@@ -59,6 +62,9 @@ describe('MuSig2 P2P Protocol Handler', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await musig2Coordinator.start()

--- a/test/p2p/musig2/replay-protection.test.ts
+++ b/test/p2p/musig2/replay-protection.test.ts
@@ -41,6 +41,9 @@ describe('MuSig2 P2P Replay Protection', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -130,6 +133,9 @@ describe('MuSig2 P2P Replay Protection', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -682,6 +688,9 @@ describe('MuSig2 P2P Replay Protection', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -887,6 +896,9 @@ describe('MuSig2 P2P Replay Protection', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -920,6 +932,9 @@ describe('MuSig2 P2P Replay Protection', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()

--- a/test/p2p/musig2/session-cleanup.test.ts
+++ b/test/p2p/musig2/session-cleanup.test.ts
@@ -70,6 +70,9 @@ describe('MuSig2 P2P Session Cleanup', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()

--- a/test/p2p/musig2/session-signatures.test.ts
+++ b/test/p2p/musig2/session-signatures.test.ts
@@ -93,6 +93,9 @@ describe('MuSig2 Session Announcement Signatures', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -203,6 +206,9 @@ describe('MuSig2 Session Announcement Signatures', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -350,12 +356,18 @@ describe('MuSig2 Session Announcement Signatures', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await aliceCoordinator.start()
@@ -495,6 +507,9 @@ describe('MuSig2 Session Announcement Signatures', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await honestCoordinator.start()
@@ -669,6 +684,9 @@ describe('MuSig2 Session Announcement Signatures', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()

--- a/test/p2p/musig2/three-phase-architecture.test.ts
+++ b/test/p2p/musig2/three-phase-architecture.test.ts
@@ -31,6 +31,9 @@ describe('MuSig2 Three-Phase Architecture', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await coordinator.start()
@@ -218,18 +221,27 @@ describe('MuSig2 Three-Phase Architecture', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       aliceCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await Promise.all([
@@ -352,18 +364,27 @@ describe('MuSig2 Three-Phase Architecture', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       aliceCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await Promise.all([
@@ -576,18 +597,27 @@ describe('MuSig2 Three-Phase Architecture', () => {
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       aliceCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       bobCoordinator = new MuSig2P2PCoordinator({
         listen: ['/ip4/127.0.0.1/tcp/0'],
         enableDHT: true,
         enableDHTServer: false,
+        securityConfig: {
+          disableRateLimiting: true,
+        },
       })
 
       await Promise.all([


### PR DESCRIPTION
This commit adds the required logic for ensuring that our own client is not rate-limiting our operations. We MUST rely on the rest of the network to decide what is appropriate.

We also add a simple bypass configuration mechanism to the P2P Coordinators for test environments.