### PR TITLE
Add proper support for bootstrap nodes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,108 @@ NNG_REQ_SOCKET_PATH="/home/user/.lotus/rpc.pipe"
 RNKC_MIN_FEE_RATE="10000000" # satoshis
 # Minimum total data length of RNKC comment data
 RNKC_MIN_DATA_LENGTH="1" # bytes
+# Lotus Library Environment Configuration
+# Copy this file to .env and configure with your values
+# NEVER commit .env files to git!
+
+# ============================================================================
+# P2P Network Configuration
+# ============================================================================
+
+# P2P Peer Identity (Ed25519 Keypair)
+# Generate these values using: npx tsx scripts/generate-p2p-keypair.ts --env
+#
+# These values provide a persistent identity for your P2P node across restarts.
+# Without these, a new random identity will be generated each time.
+
+# The public peer ID (safe to share)
+# This is the identifier other peers will use to connect to you
+# Example: 12D3KooWRnWLNiT8E1qRjKBHNQFWqDvUaDkAE7VybZ4Q1R6p7JZK
+P2P_PEER_ID=
+
+# Private key in Protocol Buffers format (base64 encoded)
+# Used with privateKeyFromProtobuf() - recommended format
+# KEEP THIS SECRET! Never share or commit to git!
+P2P_PRIVATE_KEY_BASE64=
+
+# Private key in raw format (base64 encoded)
+# Used with privateKeyFromRaw() - alternative format
+# KEEP THIS SECRET! Never share or commit to git!
+P2P_PRIVATE_KEY_RAW_BASE64=
+
+# ============================================================================
+# P2P Bootstrap Nodes
+# ============================================================================
+
+# Comma-separated list of bootstrap peer multiaddrs
+# Format: /ip4/IP/tcp/PORT/p2p/PEER_ID
+# Example: /ip4/147.135.88.232/tcp/6969/p2p/12D3KooWMHp6oNPM2ZQkCMESKyf8CDLaQ5LQVpNavKxqDKGCPETM
+P2P_BOOTSTRAP_PEERS=
+
+# ============================================================================
+# P2P Node Configuration
+# ============================================================================
+
+# Listen address for P2P connections
+# Default: /ip4/0.0.0.0/tcp/0 (random port)
+P2P_LISTEN_ADDR=/ip4/0.0.0.0/tcp/0
+
+# Announce address (optional - for NAT/firewall traversal)
+# If behind NAT, specify your public IP:PORT here
+# Example: /ip4/203.0.113.1/tcp/6969
+P2P_ANNOUNCE_ADDR=
+
+# Enable DHT server mode (true/false)
+# true: Full DHT server (for bootstrap/relay nodes)
+# false: DHT client only (for regular wallets)
+# Default: false
+P2P_DHT_SERVER=false
+
+# Enable relay server mode (true/false)
+# true: Allow others to relay through you (bootstrap nodes)
+# false: Don't act as relay (regular wallets)
+# Default: false
+P2P_RELAY_SERVER=false
+
+# ============================================================================
+# Blockchain Configuration (Chronik API)
+# ============================================================================
+
+# Chronik API URL for blockchain verification
+# Used by burn-based identity system and blockchain queries
+# Default: https://chronik.lotusia.org
+CHRONIK_URL=https://chronik.lotusia.org
+
+# ============================================================================
+# Security Configuration
+# ============================================================================
+
+# Disable rate limiting (TESTING ONLY - never use in production!)
+# Default: false
+P2P_DISABLE_RATE_LIMITING=false
+
+# ============================================================================
+# Usage Examples
+# ============================================================================
+
+# Generate a new keypair:
+#   npx tsx scripts/generate-p2p-keypair.ts --env >> .env
+#
+# Or save to a file:
+#   npx tsx scripts/generate-p2p-keypair.ts --save ./keys/my-node.key
+#
+# Load in TypeScript:
+#   import { privateKeyFromProtobuf } from '@libp2p/crypto/keys'
+#   import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+#   
+#   const keyBytes = Buffer.from(process.env.P2P_PRIVATE_KEY_BASE64!, 'base64')
+#   const privateKey = privateKeyFromProtobuf(keyBytes)
+#   const peerId = peerIdFromPrivateKey(privateKey)
+#   
+#   const coordinator = new MuSig2P2PCoordinator({
+#     peerId: peerId,
+#     bootstrapPeers: process.env.P2P_BOOTSTRAP_PEERS?.split(','),
+#     listen: [process.env.P2P_LISTEN_ADDR || '/ip4/0.0.0.0/tcp/0'],
+#     enableDHTServer: process.env.P2P_DHT_SERVER === 'true',
+#     enableRelayServer: process.env.P2P_RELAY_SERVER === 'true',
+#   })

--- a/examples/bootstrap-persistent-identity-example.ts
+++ b/examples/bootstrap-persistent-identity-example.ts
@@ -1,0 +1,221 @@
+/**
+ * Bootstrap Peer Discovery & Persistent Identity Example
+ *
+ * Demonstrates:
+ * 1. Creating a persistent peer identity (same PeerId across restarts)
+ * 2. Automatic bootstrap peer discovery (no manual connection needed)
+ *
+ * Usage:
+ *   npx tsx examples/bootstrap-persistent-identity-example.ts
+ */
+
+import { MuSig2P2PCoordinator } from '../lib/p2p/musig2/index.js'
+import {
+  generateKeyPair,
+  privateKeyToProtobuf,
+  privateKeyFromProtobuf,
+} from '@libp2p/crypto/keys'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs'
+import { dirname } from 'path'
+
+// ============================================================================
+// Helper: Get or Create Persistent PeerId
+// ============================================================================
+
+/**
+ * Get or create a persistent PeerId that remains the same across restarts
+ */
+async function getOrCreatePeerId(filepath: string) {
+  // Ensure directory exists
+  const dir = dirname(filepath)
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true })
+  }
+
+  if (existsSync(filepath)) {
+    console.log(`📂 Loading existing key from: ${filepath}`)
+    const privateKeyBytes = readFileSync(filepath)
+    const privateKey = privateKeyFromProtobuf(privateKeyBytes)
+    const peerId = peerIdFromPrivateKey(privateKey)
+    console.log(`✅ Loaded PeerId: ${peerId.toString()}\n`)
+    return peerId
+  } else {
+    console.log(`🔑 Generating new key and saving to: ${filepath}`)
+    const privateKey = await generateKeyPair('Ed25519')
+    const privateKeyBytes = privateKeyToProtobuf(privateKey)
+    writeFileSync(filepath, privateKeyBytes)
+    const peerId = peerIdFromPrivateKey(privateKey)
+    console.log(`✅ Generated PeerId: ${peerId.toString()}\n`)
+    return peerId
+  }
+}
+
+// ============================================================================
+// Example: Bootstrap Node (Zoe)
+// ============================================================================
+
+async function startBootstrapNode() {
+  console.log('=== Starting Bootstrap Node (Zoe) ===\n')
+
+  // Create persistent identity for Zoe
+  const zoePeerId = await getOrCreatePeerId('./.keys/zoe-bootstrap.key')
+
+  // Start Zoe as a bootstrap/relay node
+  const zoeCoordinator = new MuSig2P2PCoordinator({
+    listen: ['/ip4/0.0.0.0/tcp/6969'],
+    peerId: zoePeerId, // Persistent identity (same across restarts)
+    enableDHT: true,
+    enableDHTServer: true, // Full DHT server
+    enableRelay: true,
+    enableRelayServer: true, // Act as relay for NAT peers
+    enableAutoNAT: false, // Bootstrap nodes don't need this (public IP)
+    enableDCUTR: false, // Bootstrap nodes don't need this
+    enableUPnP: false,
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
+  })
+
+  await zoeCoordinator.start()
+
+  const zoeAddrs = zoeCoordinator.getStats().multiaddrs
+  console.log('✅ Zoe online with persistent identity!')
+  console.log(`   PeerId: ${zoeCoordinator.peerId}`)
+  console.log(`   Multiaddrs:`)
+  zoeAddrs.forEach(addr => console.log(`     ${addr}`))
+  console.log()
+
+  return { coordinator: zoeCoordinator, multiaddrs: zoeAddrs }
+}
+
+// ============================================================================
+// Example: Client Node (Alice) - Automatic Bootstrap Connection
+// ============================================================================
+
+async function startClientNode(bootstrapAddrs: string[]) {
+  console.log('=== Starting Client Node (Alice) ===\n')
+
+  // Create persistent identity for Alice
+  const alicePeerId = await getOrCreatePeerId('./.keys/alice-client.key')
+
+  // Start Alice with automatic bootstrap connection
+  const aliceCoordinator = new MuSig2P2PCoordinator({
+    listen: ['/ip4/0.0.0.0/tcp/0'],
+    peerId: alicePeerId, // Persistent identity
+    bootstrapPeers: bootstrapAddrs, // 🔥 Automatically connects on startup!
+    enableDHT: true,
+    enableDHTServer: false, // Client mode
+    enableRelay: true,
+    enableAutoNAT: true,
+    enableDCUTR: true,
+    enableUPnP: false,
+    securityConfig: {
+      disableRateLimiting: true, // For demo
+    },
+  })
+
+  await aliceCoordinator.start()
+
+  console.log('✅ Alice online with persistent identity!')
+  console.log(`   PeerId: ${aliceCoordinator.peerId}`)
+  console.log(`   Bootstrap peers configured: ${bootstrapAddrs.length} peer(s)`)
+  console.log('   🔄 Automatic connection in progress...\n')
+
+  return aliceCoordinator
+}
+
+// ============================================================================
+// Main Example
+// ============================================================================
+
+async function main() {
+  try {
+    // Step 1: Start Zoe (bootstrap node)
+    const { coordinator: zoeCoordinator, multiaddrs: zoeAddrs } =
+      await startBootstrapNode()
+
+    // Wait for Zoe to fully initialize
+    await new Promise(resolve => setTimeout(resolve, 1000))
+
+    // Step 2: Start Alice (client) with automatic bootstrap connection
+    const aliceCoordinator = await startClientNode([zoeAddrs[0]])
+
+    // Wait for connection to establish
+    console.log('⏳ Waiting for automatic connection...\n')
+    await new Promise(resolve => setTimeout(resolve, 3000))
+
+    // Step 3: Verify connection
+    console.log('=== Connection Status ===\n')
+
+    const aliceConnections = aliceCoordinator.libp2pNode.getConnections()
+    console.log(`Alice has ${aliceConnections.length} connection(s):`)
+    aliceConnections.forEach(conn => {
+      const remoteAddr = conn.remoteAddr.toString()
+      console.log(`  ✅ Connected to: ${remoteAddr}`)
+    })
+    console.log()
+
+    const zoeConnections = zoeCoordinator.libp2pNode.getConnections()
+    console.log(`Zoe has ${zoeConnections.length} connection(s):`)
+    zoeConnections.forEach(conn => {
+      const remoteAddr = conn.remoteAddr.toString()
+      console.log(`  ✅ Connected to: ${remoteAddr}`)
+    })
+    console.log()
+
+    // Step 4: Show DHT stats
+    console.log('=== DHT Statistics ===\n')
+
+    const aliceStats = aliceCoordinator.getDHTStats()
+    console.log('Alice DHT:')
+    console.log(`  Mode: ${aliceStats.mode}`)
+    console.log(`  Routing table size: ${aliceStats.routingTableSize}`)
+    console.log(`  Ready: ${aliceStats.isReady}`)
+    console.log()
+
+    const zoeStats = zoeCoordinator.getDHTStats()
+    console.log('Zoe DHT:')
+    console.log(`  Mode: ${zoeStats.mode}`)
+    console.log(`  Routing table size: ${zoeStats.routingTableSize}`)
+    console.log(`  Ready: ${zoeStats.isReady}`)
+    console.log()
+
+    // Summary
+    console.log('=== Summary ===\n')
+    console.log('✅ Features demonstrated:')
+    console.log(
+      '   1. Persistent PeerId: Both nodes use saved keys (.keys/*.key)',
+    )
+    console.log(
+      '   2. Automatic bootstrap: Alice connected without manual connectToPeer()',
+    )
+    console.log('   3. DHT participation: Both nodes joined the DHT network')
+    console.log()
+    console.log('🎉 Success! Alice automatically connected to Zoe on startup!')
+    console.log()
+    console.log(
+      '💡 Restart this script - both nodes will have the same PeerIds!',
+    )
+    console.log()
+
+    // Keep running for a bit
+    console.log('Press Ctrl+C to stop...\n')
+
+    // Cleanup on exit
+    process.on('SIGINT', async () => {
+      console.log('\n\nShutting down...')
+      await Promise.all([aliceCoordinator.stop(), zoeCoordinator.stop()])
+      console.log('✅ All coordinators stopped')
+      process.exit(0)
+    })
+
+    // Keep alive
+    await new Promise(() => {})
+  } catch (error) {
+    console.error('Error:', error)
+    process.exit(1)
+  }
+}
+
+main()

--- a/examples/musig2-three-phase-example.ts
+++ b/examples/musig2-three-phase-example.ts
@@ -59,7 +59,7 @@ async function threePhaseExample() {
   // ========================================================================
 
   const aliceCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'], // TCP transport (primary for Node.js)
+    listen: ['/ip4/127.0.0.1/tcp/0'], // TCP transport (primary for Node.js)
     enableDHT: true,
     enableDHTServer: false,
     enableRelay: true, // Circuit Relay v2 (PRIMARY NAT solution)
@@ -74,7 +74,7 @@ async function threePhaseExample() {
   })
 
   const bobCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
     enableRelay: true,
@@ -87,7 +87,7 @@ async function threePhaseExample() {
   })
 
   const charlieCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
     enableRelay: true,
@@ -433,7 +433,7 @@ async function advertisementExample() {
   console.log('\n=== Signer Advertisement Example ===\n')
 
   const coordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableRelay: true,
     enableAutoNAT: true,
@@ -565,7 +565,7 @@ async function matchmakingDHTExample() {
 
   // Bob runs a signing service (Circuit Relay enabled for NAT traversal)
   const bobCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true, // Bob participates in DHT routing
     enableRelay: true, // Circuit Relay for NAT traversal
@@ -579,7 +579,7 @@ async function matchmakingDHTExample() {
 
   // Charlie runs a signing service (Circuit Relay enabled for NAT traversal)
   const charlieCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true, // Charlie participates in DHT routing
     enableRelay: true, // Circuit Relay for NAT traversal
@@ -710,7 +710,7 @@ async function matchmakingDHTExample() {
 
   // Alice creates her coordinator (client mode with Circuit Relay)
   const aliceCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false, // Alice is a client, not a DHT server
     enableRelay: true, // Circuit Relay for NAT traversal
@@ -1067,7 +1067,7 @@ async function matchmakingGossipSubExample() {
   console.log('--- Phase 1: Alice Joins and Subscribes ---\n')
 
   const aliceCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: false,
     enableGossipSub: true,
@@ -1119,7 +1119,7 @@ async function matchmakingGossipSubExample() {
   console.log('--- Phase 2: Bob & Charlie Join and Advertise ---\n')
 
   const bobCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true,
     enableGossipSub: true,
@@ -1130,7 +1130,7 @@ async function matchmakingGossipSubExample() {
   })
 
   const charlieCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableDHTServer: true,
     enableGossipSub: true,
@@ -1364,7 +1364,7 @@ async function eventDrivenExample() {
   console.log('\n=== Event-Driven Discovery Example ===\n')
 
   const coordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/0.0.0.0/tcp/0'],
+    listen: ['/ip4/127.0.0.1/tcp/0'],
     enableDHT: true,
     enableRelay: true,
     enableAutoNAT: true,

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -5,8 +5,7 @@
  */
 
 import { PublicKey } from '../bitcore/publickey.js'
-import type { Connection, Stream } from '@libp2p/interface'
-import type { PeerId } from '@libp2p/interface-peer-id'
+import type { Connection, Stream, PeerId } from '@libp2p/interface'
 import type { Multiaddr } from '@multiformats/multiaddr'
 import type { Libp2p } from 'libp2p'
 import type { PeerInfoMapper } from '@libp2p/kad-dht'
@@ -114,13 +113,24 @@ export enum ConnectionEvent {
  * P2P Configuration
  */
 export interface P2PConfig {
+  /**
+   * Fixed peer identity (optional - for persistent node identity across restarts)
+   * When provided, the node will use this PeerId instead of generating a random one
+   * The PeerId contains both public and private keys for node authentication
+   */
+  peerId?: PeerId
+
   /** Listen addresses (multiaddrs) */
   listen?: string[]
 
   /** Announce addresses (multiaddrs) */
   announce?: string[]
 
-  /** Bootstrap peer addresses */
+  /**
+   * Bootstrap peer addresses (multiaddrs with peer IDs)
+   * When provided, the node will automatically connect to these peers on startup
+   * Example: ['/ip4/135.148.150.142/tcp/6969/p2p/12D3KooW...']
+   */
   bootstrapPeers?: string[]
 
   /** Enable Kad-DHT */

--- a/scripts/generate-p2p-keypair.ts
+++ b/scripts/generate-p2p-keypair.ts
@@ -1,0 +1,170 @@
+#!/usr/bin/env node
+/**
+ * Generate Ed25519 Keypair for P2P Identity
+ *
+ * This script generates a new Ed25519 keypair for use with libp2p.
+ * The keypair can be used to create a persistent peer identity that
+ * remains the same across restarts.
+ *
+ * Usage:
+ *   npx tsx scripts/generate-p2p-keypair.ts [--save <filename>]
+ *
+ * Options:
+ *   --save <filename>  Save the private key to a file (e.g., zoe-bootstrap.key)
+ *   --env              Output in .env format
+ *   --help             Show this help message
+ *
+ * Examples:
+ *   # Generate and display keypair
+ *   npx tsx scripts/generate-p2p-keypair.ts
+ *
+ *   # Generate and save to file
+ *   npx tsx scripts/generate-p2p-keypair.ts --save ./keys/bootstrap.key
+ *
+ *   # Generate for .env file
+ *   npx tsx scripts/generate-p2p-keypair.ts --env
+ */
+
+import { generateKeyPair, privateKeyToProtobuf } from '@libp2p/crypto/keys'
+import { peerIdFromPrivateKey } from '@libp2p/peer-id'
+import { writeFileSync, mkdirSync, existsSync } from 'fs'
+import { dirname } from 'path'
+
+// Parse command line arguments
+const args = process.argv.slice(2)
+const saveFlag = args.indexOf('--save')
+const envFlag = args.includes('--env')
+const helpFlag = args.includes('--help')
+
+if (helpFlag) {
+  console.log(`
+Generate Ed25519 Keypair for P2P Identity
+
+Usage:
+  npx tsx scripts/generate-p2p-keypair.ts [options]
+
+Options:
+  --save <filename>  Save the private key to a file
+  --env              Output in .env format
+  --help             Show this help message
+
+Examples:
+  # Generate and display keypair
+  npx tsx scripts/generate-p2p-keypair.ts
+
+  # Generate and save to file
+  npx tsx scripts/generate-p2p-keypair.ts --save ./keys/bootstrap.key
+
+  # Generate for .env file
+  npx tsx scripts/generate-p2p-keypair.ts --env
+`)
+  process.exit(0)
+}
+
+async function main() {
+  console.log('🔑 Generating Ed25519 keypair...\n')
+
+  // Generate new Ed25519 keypair
+  const privateKey = await generateKeyPair('Ed25519')
+
+  // Create PeerId from the keypair
+  const peerId = peerIdFromPrivateKey(privateKey)
+
+  // Export private key as Protocol Buffers bytes
+  const privateKeyBytes = privateKeyToProtobuf(privateKey)
+  const privateKeyBase64 = Buffer.from(privateKeyBytes).toString('base64')
+
+  // Export raw private key bytes (for @libp2p/crypto/keys privateKeyFromRaw)
+  const privateKeyRaw = privateKey.raw
+  const privateKeyRawBase64 = Buffer.from(privateKeyRaw).toString('base64')
+
+  if (envFlag) {
+    // Output in .env format
+    console.log('# Add these to your .env file:\n')
+    console.log(`P2P_PEER_ID=${peerId.toString()}`)
+    console.log(`P2P_PRIVATE_KEY_BASE64=${privateKeyBase64}`)
+    console.log(`P2P_PRIVATE_KEY_RAW_BASE64=${privateKeyRawBase64}`)
+    console.log('')
+  } else {
+    // Display in human-readable format
+    console.log('✅ Keypair generated successfully!\n')
+    console.log('═══════════════════════════════════════════════════════════\n')
+    console.log('📋 Peer ID (Public Identity):')
+    console.log(`   ${peerId.toString()}\n`)
+    console.log('🔐 Private Key (Protocol Buffers format):')
+    console.log(`   ${privateKeyBase64}\n`)
+    console.log('🔐 Private Key (Raw format):')
+    console.log(`   ${privateKeyRawBase64}\n`)
+    console.log('═══════════════════════════════════════════════════════════\n')
+  }
+
+  // Save to file if requested
+  if (saveFlag !== -1 && args[saveFlag + 1]) {
+    const filename = args[saveFlag + 1]
+
+    // Ensure directory exists
+    const dir = dirname(filename)
+    if (dir !== '.' && !existsSync(dir)) {
+      mkdirSync(dir, { recursive: true })
+    }
+
+    // Write private key to file (Protocol Buffers format)
+    writeFileSync(filename, privateKeyBytes)
+
+    console.log(`💾 Private key saved to: ${filename}`)
+    console.log(`   File size: ${privateKeyBytes.length} bytes\n`)
+  }
+
+  if (!envFlag) {
+    console.log('📝 Usage in TypeScript:\n')
+    console.log('```typescript')
+    console.log("import { privateKeyFromProtobuf } from '@libp2p/crypto/keys'")
+    console.log("import { peerIdFromPrivateKey } from '@libp2p/peer-id'")
+    console.log("import { readFileSync } from 'fs'")
+    console.log('')
+    console.log('// Load from file:')
+    console.log(
+      `const keyBytes = readFileSync('${saveFlag !== -1 ? args[saveFlag + 1] : 'path/to/key.key'}')`,
+    )
+    console.log('const privateKey = privateKeyFromProtobuf(keyBytes)')
+    console.log('const peerId = peerIdFromPrivateKey(privateKey)')
+    console.log('')
+    console.log('// Or load from environment variable:')
+    console.log(
+      "const keyBytes = Buffer.from(process.env.P2P_PRIVATE_KEY_BASE64!, 'base64')",
+    )
+    console.log('const privateKey = privateKeyFromProtobuf(keyBytes)')
+    console.log('const peerId = peerIdFromPrivateKey(privateKey)')
+    console.log('')
+    console.log('// Use in coordinator:')
+    console.log('const coordinator = new MuSig2P2PCoordinator({')
+    console.log('  peerId: peerId,')
+    console.log("  listen: ['/ip4/0.0.0.0/tcp/6969'],")
+    console.log('  // ... other config')
+    console.log('})')
+    console.log('```\n')
+
+    console.log('🔒 Security Warning:')
+    console.log('   - Never commit private keys to git!')
+    console.log('   - Add *.key to .gitignore')
+    console.log('   - Keep .env files secure')
+    console.log('   - Use appropriate file permissions (chmod 600)\n')
+
+    console.log('💡 Next Steps:')
+    if (saveFlag === -1) {
+      console.log('   1. Run with --save to save the key to a file')
+      console.log('   2. Or run with --env to output in .env format')
+    } else {
+      console.log('   1. Add the key file to .gitignore')
+      console.log('   2. Use the peerId in your bootstrap configuration')
+      console.log('   3. Share the multiaddr with clients:')
+      console.log(`      /ip4/YOUR_IP/tcp/YOUR_PORT/p2p/${peerId.toString()}`)
+    }
+    console.log('')
+  }
+}
+
+main().catch(error => {
+  console.error('❌ Error:', error)
+  process.exit(1)
+})


### PR DESCRIPTION
This commit ensures that the bootstrap nodes for `P2PCoordinator` are properly set up to handle bootstrapping.

Along with this change comes changes that revert previous fixes for the `passthroughMapper`. To ensure the 3-phase example still works, we update the example to directly use localhost IP address to listen.

We also add a new script that can be used to generate keypairs for persistent P2P `PeerID` configurations.