### PR TITLE
Add support for `peer:discovery` event

### DIFF
--- a/examples/musig2-three-phase-example.ts
+++ b/examples/musig2-three-phase-example.ts
@@ -15,6 +15,7 @@ import {
 } from '../lib/p2p/musig2/index.js'
 import { PrivateKey } from '../lib/bitcore/privatekey.js'
 import { PublicKey } from '../lib/bitcore/publickey.js'
+import { resolve } from 'path'
 
 // ============================================================================
 // Example: Complete Three-Phase MuSig2 Coordination
@@ -1064,12 +1065,61 @@ async function matchmakingGossipSubExample() {
   // Phase 1: Alice Connects and Subscribes FIRST
   // ========================================================================
 
+  // ========================================================================
+  // Phase 2: Service Providers Connect and Advertise
+  // ========================================================================
+
+  console.log('--- Phase 2: Bob & Charlie Join and Advertise ---\n')
+
+  const bobCoordinator = new MuSig2P2PCoordinator({
+    listen: ['/ip4/127.0.0.1/tcp/0'],
+    bootstrapPeers: [zoeBootstrapAddr],
+    enableDHT: true,
+    enableDHTServer: true,
+    enableGossipSub: true,
+    enableRelay: true,
+    enableAutoNAT: true,
+    enableDCUTR: true,
+    enableUPnP: false,
+  })
+
+  const charlieCoordinator = new MuSig2P2PCoordinator({
+    listen: ['/ip4/127.0.0.1/tcp/0'],
+    bootstrapPeers: [zoeBootstrapAddr],
+    enableDHT: true,
+    enableDHTServer: true,
+    enableGossipSub: true,
+    enableRelay: true,
+    enableAutoNAT: true,
+    enableDCUTR: true,
+    enableUPnP: false,
+  })
+
+  await Promise.all([bobCoordinator.start(), charlieCoordinator.start()])
+
+  console.log('✅ Service providers started')
+  console.log(`   Bob: ${bobCoordinator.peerId}`)
+  console.log(`   Charlie: ${charlieCoordinator.peerId}\n`)
+
+  // Connect to bootstrap
+  /* console.log('🔗 Bob & Charlie connecting to Zoe...')
+  await Promise.all([
+    bobCoordinator.connectToPeer(zoeBootstrapAddr),
+    charlieCoordinator.connectToPeer(zoeBootstrapAddr),
+  ])
+  console.log('✅ Connected\n') */
+
+  // Wait for GossipSub mesh to form
+  console.log('⏳ Waiting for GossipSub mesh to form...\n')
+  await new Promise(resolve => setTimeout(resolve, 1000))
+
   console.log('--- Phase 1: Alice Joins and Subscribes ---\n')
 
   const aliceCoordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/127.0.0.1/tcp/0'],
+    bootstrapPeers: [zoeBootstrapAddr],
     enableDHT: true,
-    enableDHTServer: false,
+    enableDHTServer: true,
     enableGossipSub: true,
     enableRelay: true,
     enableAutoNAT: true,
@@ -1082,7 +1132,7 @@ async function matchmakingGossipSubExample() {
 
   // Connect to bootstrap
   console.log('🔗 Alice connecting to Zoe...')
-  await aliceCoordinator.connectToPeer(zoeBootstrapAddr)
+  //await aliceCoordinator.connectToPeer(zoeBootstrapAddr)
   console.log('✅ Connected\n')
 
   // Subscribe BEFORE advertisers join
@@ -1110,53 +1160,7 @@ async function matchmakingGossipSubExample() {
   console.log('✅ Alice subscribed and waiting for advertisements\n')
 
   // Wait for subscription to propagate
-  await new Promise(resolve => setTimeout(resolve, 500))
-
-  // ========================================================================
-  // Phase 2: Service Providers Connect and Advertise
-  // ========================================================================
-
-  console.log('--- Phase 2: Bob & Charlie Join and Advertise ---\n')
-
-  const bobCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/127.0.0.1/tcp/0'],
-    enableDHT: true,
-    enableDHTServer: true,
-    enableGossipSub: true,
-    enableRelay: true,
-    enableAutoNAT: true,
-    enableDCUTR: true,
-    enableUPnP: false,
-  })
-
-  const charlieCoordinator = new MuSig2P2PCoordinator({
-    listen: ['/ip4/127.0.0.1/tcp/0'],
-    enableDHT: true,
-    enableDHTServer: true,
-    enableGossipSub: true,
-    enableRelay: true,
-    enableAutoNAT: true,
-    enableDCUTR: true,
-    enableUPnP: false,
-  })
-
-  await Promise.all([bobCoordinator.start(), charlieCoordinator.start()])
-
-  console.log('✅ Service providers started')
-  console.log(`   Bob: ${bobCoordinator.peerId}`)
-  console.log(`   Charlie: ${charlieCoordinator.peerId}\n`)
-
-  // Connect to bootstrap
-  console.log('🔗 Bob & Charlie connecting to Zoe...')
-  await Promise.all([
-    bobCoordinator.connectToPeer(zoeBootstrapAddr),
-    charlieCoordinator.connectToPeer(zoeBootstrapAddr),
-  ])
-  console.log('✅ Connected\n')
-
-  // Wait for GossipSub mesh to form
-  console.log('⏳ Waiting for GossipSub mesh to form...\n')
-  await new Promise(resolve => setTimeout(resolve, 1000))
+  await new Promise(resolve => setTimeout(resolve, 2000))
 
   // Advertise (Alice will receive via GossipSub!)
   console.log('📡 Bob and Charlie advertising...')
@@ -1439,7 +1443,7 @@ async function eventDrivenExample() {
 
 async function main() {
   try {
-    // Run full three-phase example
+    /* // Run full three-phase example
     await threePhaseExample()
 
     // Run advertisement example
@@ -1450,7 +1454,7 @@ async function main() {
     // Run matchmaking example (DHT-based discovery)
     await matchmakingDHTExample()
 
-    await new Promise(resolve => setTimeout(resolve, 1500))
+    await new Promise(resolve => setTimeout(resolve, 1500)) */
 
     // Run GossipSub example (event-driven discovery)
     await matchmakingGossipSubExample()

--- a/examples/p2p-peer-discovery-example.ts
+++ b/examples/p2p-peer-discovery-example.ts
@@ -1,0 +1,242 @@
+/**
+ * Peer Discovery Example with Bootstrap Nodes
+ *
+ * Demonstrates how the P2P layer handles peer discovery through bootstrap nodes
+ * and notifies protocol handlers universally (not specific to any protocol)
+ */
+
+import {
+  P2PCoordinator,
+  P2PMessage,
+  PeerInfo,
+  IProtocolHandler,
+  ConnectionEvent,
+} from '../lib/p2p/index.js'
+
+/**
+ * Example Protocol Handler that reacts to peer discovery
+ * This could be any protocol (MuSig2, CoinJoin, etc.)
+ */
+class DiscoveryAwareProtocolHandler implements IProtocolHandler {
+  readonly protocolName = 'discovery-demo'
+  readonly protocolId = '/lotus/discovery-demo/1.0.0'
+
+  private discoveredPeers: Set<string> = new Set()
+  private connectedPeers: Set<string> = new Set()
+
+  constructor(
+    private coordinator: P2PCoordinator,
+    private name: string,
+  ) {}
+
+  async handleMessage(message: P2PMessage, from: PeerInfo): Promise<void> {
+    // Handle protocol messages
+    console.log(
+      `[${this.name}] Received message from ${from.peerId.substring(0, 12)}...`,
+    )
+  }
+
+  /**
+   * Peer Discovery Handler
+   * Called when bootstrap nodes or DHT discover peers
+   * This happens BEFORE connection is established
+   */
+  async onPeerDiscovered(peerInfo: PeerInfo): Promise<void> {
+    this.discoveredPeers.add(peerInfo.peerId)
+
+    console.log(`\n🔍 [${this.name}] PEER DISCOVERED:`)
+    console.log(`   Peer ID: ${peerInfo.peerId.substring(0, 20)}...`)
+    console.log(`   Multiaddrs: ${peerInfo.multiaddrs?.length || 0}`)
+    if (peerInfo.multiaddrs && peerInfo.multiaddrs.length > 0) {
+      peerInfo.multiaddrs.forEach(addr => {
+        console.log(`      - ${addr}`)
+      })
+    }
+    console.log(
+      `   Total discovered: ${this.discoveredPeers.size} peers (not yet connected)`,
+    )
+
+    // Protocol-specific logic could be added here:
+    // - Check if peer advertises required services
+    // - Decide whether to attempt connection
+    // - Store peer info for later use
+  }
+
+  /**
+   * Peer Connection Handler
+   * Called AFTER successful connection establishment
+   */
+  async onPeerConnected(peerId: string): Promise<void> {
+    this.connectedPeers.add(peerId)
+
+    console.log(`\n✅ [${this.name}] PEER CONNECTED:`)
+    console.log(`   Peer ID: ${peerId.substring(0, 20)}...`)
+    console.log(
+      `   Total connected: ${this.connectedPeers.size} peers (ready for protocol operations)`,
+    )
+
+    // At this point, the peer is ready for protocol operations
+    // - Can send messages
+    // - Can open streams
+    // - Can participate in protocol sessions
+  }
+
+  /**
+   * Peer Disconnection Handler
+   */
+  async onPeerDisconnected(peerId: string): Promise<void> {
+    this.connectedPeers.delete(peerId)
+
+    console.log(`\n❌ [${this.name}] PEER DISCONNECTED:`)
+    console.log(`   Peer ID: ${peerId.substring(0, 20)}...`)
+    console.log(`   Remaining connected: ${this.connectedPeers.size} peers`)
+
+    // Clean up protocol-specific state for this peer
+  }
+
+  getStats() {
+    return {
+      discovered: this.discoveredPeers.size,
+      connected: this.connectedPeers.size,
+    }
+  }
+}
+
+/**
+ * Main demonstration
+ */
+async function main() {
+  console.log('═════════════════════════════════════════════════════════')
+  console.log('  Peer Discovery Example with Bootstrap Nodes')
+  console.log('═════════════════════════════════════════════════════════\n')
+
+  console.log('This example demonstrates:')
+  console.log('  1. Bootstrap node discovery (libp2p built-in)')
+  console.log('  2. Universal peer discovery event handling')
+  console.log('  3. Protocol handler notifications')
+  console.log('  4. Discovery → Connection → Protocol Operations flow\n')
+
+  // Create a bootstrap node (acts as discovery hub)
+  console.log('📡 Setting up bootstrap node...')
+  const bootstrap = new P2PCoordinator({
+    listen: ['/ip4/127.0.0.1/tcp/9000'],
+    enableDHT: true,
+    enableDHTServer: true, // Server mode for bootstrap
+    enableRelayServer: true, // Act as relay for NAT peers
+  })
+
+  await bootstrap.start()
+  const bootstrapAddr = bootstrap.libp2pNode.getMultiaddrs()[0].toString()
+  console.log('✓ Bootstrap node started')
+  console.log(`  Peer ID: ${bootstrap.peerId.substring(0, 20)}...`)
+  console.log(`  Address: ${bootstrapAddr}\n`)
+
+  // Create client nodes that will discover each other via bootstrap
+  console.log('👤 Setting up client nodes...')
+
+  const alice = new P2PCoordinator({
+    listen: ['/ip4/127.0.0.1/tcp/0'],
+    bootstrapPeers: [bootstrapAddr], // Connect to bootstrap
+    enableDHT: true,
+    enableDHTServer: false, // Client mode
+  })
+
+  const bob = new P2PCoordinator({
+    listen: ['/ip4/127.0.0.1/tcp/0'],
+    bootstrapPeers: [bootstrapAddr], // Connect to bootstrap
+    enableDHT: true,
+    enableDHTServer: false, // Client mode
+  })
+
+  // Register protocol handlers (will receive discovery events)
+  const aliceProtocol = new DiscoveryAwareProtocolHandler(alice, 'Alice')
+  const bobProtocol = new DiscoveryAwareProtocolHandler(bob, 'Bob')
+
+  alice.registerProtocol(aliceProtocol)
+  bob.registerProtocol(bobProtocol)
+
+  await alice.start()
+  await bob.start()
+
+  console.log('✓ Client nodes started')
+  console.log(`  Alice: ${alice.peerId.substring(0, 20)}...`)
+  console.log(`  Bob: ${bob.peerId.substring(0, 20)}...\n`)
+
+  console.log('🔗 Discovery Process:')
+  console.log('─────────────────────────────────────────────────────────')
+  console.log('Alice and Bob will:')
+  console.log('  1. Connect to bootstrap node (automatic)')
+  console.log('  2. Discover each other via bootstrap (automatic)')
+  console.log('  3. Receive onPeerDiscovered notifications')
+  console.log('  4. Bootstrap attempts to establish connections')
+  console.log('  5. Receive onPeerConnected notifications')
+  console.log('  6. Ready for protocol operations\n')
+
+  // Wait for discovery and connections to happen
+  console.log('⏳ Waiting for peer discovery and connections...\n')
+
+  // Listen to coordinator-level events
+  alice.on(ConnectionEvent.DISCOVERED, (peerInfo: PeerInfo) => {
+    console.log(
+      `[Coordinator] Alice discovered peer: ${peerInfo.peerId.substring(0, 12)}...`,
+    )
+  })
+
+  bob.on(ConnectionEvent.DISCOVERED, (peerInfo: PeerInfo) => {
+    console.log(
+      `[Coordinator] Bob discovered peer: ${peerInfo.peerId.substring(0, 12)}...`,
+    )
+  })
+
+  // Wait for connections to establish
+  await new Promise(resolve => setTimeout(resolve, 3000))
+
+  // Show final stats
+  console.log('\n═════════════════════════════════════════════════════════')
+  console.log('  Final Statistics')
+  console.log('═════════════════════════════════════════════════════════\n')
+
+  const aliceStats = alice.getStats()
+  const bobStats = bob.getStats()
+  const aliceProtocolStats = aliceProtocol.getStats()
+  const bobProtocolStats = bobProtocol.getStats()
+
+  console.log('Alice:')
+  console.log(`  Coordinator: ${aliceStats.peers.connected} connected peers`)
+  console.log(
+    `  Protocol: ${aliceProtocolStats.discovered} discovered, ${aliceProtocolStats.connected} connected`,
+  )
+  console.log()
+
+  console.log('Bob:')
+  console.log(`  Coordinator: ${bobStats.peers.connected} connected peers`)
+  console.log(
+    `  Protocol: ${bobProtocolStats.discovered} discovered, ${bobProtocolStats.connected} connected`,
+  )
+  console.log()
+
+  console.log('Key Insights:')
+  console.log('─────────────────────────────────────────────────────────')
+  console.log('✓ Peer discovery events are handled universally at P2P layer')
+  console.log('✓ Protocol handlers are notified automatically')
+  console.log('✓ Works with any protocol (MuSig2, CoinJoin, etc.)')
+  console.log('✓ Bootstrap nodes enable decentralized peer discovery')
+  console.log('✓ Clients can find each other without hardcoded addresses\n')
+
+  console.log('Real-world Usage:')
+  console.log('  • Wallet UX discovers MuSig2 signers via bootstrap')
+  console.log('  • CoinJoin clients discover round coordinators')
+  console.log('  • Protocol handlers react to discovery events')
+  console.log('  • Bootstrap network enables decentralized discovery\n')
+
+  // Cleanup
+  await alice.stop()
+  await bob.stop()
+  await bootstrap.stop()
+
+  console.log('═════════════════════════════════════════════════════════')
+  console.log('  Example Complete!')
+  console.log('═════════════════════════════════════════════════════════')
+}
+
+main().catch(console.error)

--- a/examples/p2p-protocol-extension-example.ts
+++ b/examples/p2p-protocol-extension-example.ts
@@ -86,17 +86,33 @@ class ChatProtocolHandler implements IProtocolHandler {
   }
 
   /**
-   * Handle peer connection
+   * Handle peer discovery (before connection)
+   * Called when bootstrap nodes discover peers
+   */
+  async onPeerDiscovered(peerInfo: PeerInfo): Promise<void> {
+    console.log(
+      `[Chat] Peer discovered: ${peerInfo.peerId.substring(0, 12)}...`,
+    )
+    console.log(
+      `       Multiaddrs: ${peerInfo.multiaddrs?.length || 0} addresses`,
+    )
+    // Protocol can react to discovery (e.g., check if peer supports chat)
+    // Bootstrap module will automatically attempt to connect
+  }
+
+  /**
+   * Handle peer connection (after successful connection)
    */
   async onPeerConnected(peerId: string): Promise<void> {
-    console.log(`[Chat] New peer connected: ${peerId}`)
+    console.log(`[Chat] New peer connected: ${peerId.substring(0, 12)}...`)
+    console.log(`       Ready for chat protocol operations`)
   }
 
   /**
    * Handle peer disconnection
    */
   async onPeerDisconnected(peerId: string): Promise<void> {
-    console.log(`[Chat] Peer disconnected: ${peerId}`)
+    console.log(`[Chat] Peer disconnected: ${peerId.substring(0, 12)}...`)
     // Remove from all chat rooms
     for (const members of this.chatRooms.values()) {
       members.delete(peerId)

--- a/lib/p2p/musig2/protocol-handler.ts
+++ b/lib/p2p/musig2/protocol-handler.ts
@@ -186,7 +186,17 @@ export class MuSig2ProtocolHandler implements IProtocolHandler {
   }
 
   /**
-   * Handle peer connection
+   * Handle peer discovery (before connection established)
+   * Called when bootstrap nodes discover peers on the network
+   */
+  async onPeerDiscovered(peerInfo: PeerInfo): Promise<void> {
+    if (this.coordinator) {
+      this.coordinator._onPeerDiscovered(peerInfo)
+    }
+  }
+
+  /**
+   * Handle peer connection (after successful connection)
    */
   async onPeerConnected(peerId: string): Promise<void> {
     if (this.coordinator) {

--- a/lib/p2p/musig2/types.ts
+++ b/lib/p2p/musig2/types.ts
@@ -16,6 +16,7 @@ import {
   MuSigSession,
   MuSigSessionPhase,
 } from '../../bitcore/musig2/session.js'
+import { PeerInfo } from '../types.js'
 
 // ============================================================================
 // Event Names
@@ -60,6 +61,7 @@ export enum MuSig2Event {
   SESSION_FAILOVER_EXHAUSTED = 'session:failover-exhausted',
 
   // Peer Connection Events
+  PEER_DISCOVERED = 'peer:discovered', // Peer discovered via bootstrap (before connection)
   PEER_CONNECTED = 'peer:connected',
   PEER_DISCONNECTED = 'peer:disconnected',
 
@@ -141,6 +143,7 @@ export type MuSig2EventMap = {
   ) => void
 
   // Peer Connection Events
+  [MuSig2Event.PEER_DISCOVERED]: (peerInfo: PeerInfo) => void
   [MuSig2Event.PEER_CONNECTED]: (peerId: string) => void
   [MuSig2Event.PEER_DISCONNECTED]: (peerId: string) => void
 
@@ -355,6 +358,20 @@ export interface MuSig2P2PConfig {
    * Set to 0 to disable maturation requirement
    */
   burnMaturationPeriod?: number
+
+  /**
+   * Enable automatic connection to discovered peers
+   * Default: true
+   * When enabled, automatically attempts to connect to peers discovered via bootstrap
+   */
+  enableAutoConnect?: boolean
+
+  /**
+   * Minimum reputation score required for auto-connection (0-100)
+   * Default: 0 (connect to all discovered peers)
+   * Only applies when enableBurnBasedIdentity is true
+   */
+  minReputationForAutoConnect?: number
 }
 
 /**

--- a/lib/p2p/types.ts
+++ b/lib/p2p/types.ts
@@ -273,6 +273,9 @@ export interface IProtocolHandler {
   /** Handle incoming message */
   handleMessage(message: P2PMessage, from: PeerInfo): Promise<void>
 
+  /** Handle peer discovery (before connection is established) */
+  onPeerDiscovered?(peerInfo: PeerInfo): Promise<void>
+
   /** Handle peer connection */
   onPeerConnected?(peerId: string): Promise<void>
 

--- a/utils/settings.ts
+++ b/utils/settings.ts
@@ -6,11 +6,8 @@
 import { config } from 'dotenv'
 import { RNKC_MIN_DATA_LENGTH, RNKC_MIN_FEE_RATE } from '../utils/constants.js'
 
-const parsed = config({ path: '.env' }).parsed
-
-if (!parsed) {
-  throw new Error('Failed to load .env file')
-}
+// Load .env file if it exists (optional for P2P settings)
+const parsed = config({ path: '.env' }).parsed || {}
 
 export const RPC = {
   user: parsed.NODE_RPC_USER,
@@ -22,4 +19,37 @@ export const RPC = {
 export const RNKC = {
   minFeeRate: Number(parsed.RNKC_MIN_FEE_RATE) || RNKC_MIN_FEE_RATE,
   minDataLength: Number(parsed.RNKC_MIN_DATA_LENGTH) || RNKC_MIN_DATA_LENGTH,
+}
+
+/**
+ * P2P Network Configuration
+ *
+ * These limits apply to general P2P network connections (DHT, GossipSub, discovery).
+ * MuSig2 session-specific connections are managed separately and are not counted
+ * against these limits.
+ *
+ * Sane Defaults:
+ * - maxConnections: 50 (adequate for most client nodes)
+ * - minConnections: 10 (maintains network health)
+ *
+ * Recommended Ranges:
+ * - Client nodes: 20-100 max, 5-20 min
+ * - Bootstrap nodes: 100-500 max, 20-50 min
+ *
+ * Environment Variables:
+ * - P2P_MAX_CONNECTIONS: Maximum general P2P connections (default: 50)
+ * - P2P_MIN_CONNECTIONS: Minimum connections to maintain (default: 10)
+ */
+export const P2P = {
+  /**
+   * Maximum number of general P2P connections
+   * This is separate from MuSig2 session-specific connections
+   */
+  maxConnections: Number(parsed?.P2P_MAX_CONNECTIONS) || 50,
+
+  /**
+   * Minimum number of P2P connections to maintain
+   * libp2p will try to keep at least this many connections
+   */
+  minConnections: Number(parsed?.P2P_MIN_CONNECTIONS) || 10,
 }


### PR DESCRIPTION
This commit adds the necessary handlers to the core P2P modules for auto-discovering peers, as well as auto-connecting to them once they are discovered. We also integrate this logic into the MuSig2 P2P modules.

Documentation was updated to reflect these changes.