### PR TITLE
Remove self-reported reputation from signer advertisements

### DIFF
--- a/lib/p2p/musig2/coordinator.ts
+++ b/lib/p2p/musig2/coordinator.ts
@@ -870,14 +870,6 @@ export class MuSig2P2PCoordinator extends P2PCoordinator {
         continue
       }
 
-      if (
-        filters.minReputation &&
-        advertisement.metadata?.reputation &&
-        advertisement.metadata.reputation.score < filters.minReputation
-      ) {
-        continue
-      }
-
       results.push(advertisement)
       seenPublicKeys.add(advertisement.publicKey.toString())
 
@@ -916,14 +908,6 @@ export class MuSig2P2PCoordinator extends P2PCoordinator {
           filters.maxAmount &&
           advertisement.criteria.minAmount &&
           advertisement.criteria.minAmount > filters.maxAmount
-        ) {
-          continue
-        }
-
-        if (
-          filters.minReputation &&
-          advertisement.metadata?.reputation &&
-          advertisement.metadata.reputation.score < filters.minReputation
         ) {
           continue
         }

--- a/lib/p2p/musig2/types.ts
+++ b/lib/p2p/musig2/types.ts
@@ -481,14 +481,6 @@ export interface SignerCriteria {
 
   /** Maximum XPI amount (in satoshis) */
   maxAmount?: number
-
-  /** Trust requirements */
-  trustRequirements?: {
-    /** Minimum reputation score (0-100) */
-    reputation?: number
-    /** Requires identity verification */
-    requiresVerification?: boolean
-  }
 }
 
 /**
@@ -518,14 +510,6 @@ export interface SignerAdvertisement {
     fees?: number
     /** Average response time (milliseconds) */
     responseTime?: number
-    /** Reputation data */
-    reputation?: {
-      score: number // 0-100
-      completedSignings: number
-      failedSignings: number
-      averageResponseTime: number
-      verifiedIdentity: boolean
-    }
   }
 
   /** Creation timestamp */
@@ -566,9 +550,6 @@ export interface SignerSearchFilters {
 
   /** Maximum XPI amount (in satoshis) */
   maxAmount?: number
-
-  /** Minimum reputation score (0-100) */
-  minReputation?: number
 
   /** Maximum number of results to return */
   maxResults?: number


### PR DESCRIPTION
Self-reported reputation in SignerAdvertisement.metadata provides no security value as attackers can claim arbitrary scores to bypass filters.

Changes:
- Remove SignerAdvertisement.metadata.reputation object
- Remove SignerCriteria.trustRequirements
- Remove SignerSearchFilters.minReputation
- Remove coordinator filtering based on advertised reputation

Local reputation tracking (PeerReputationManager, IdentityReputation) remains intact and continues to track observed peer behavior.