### PR TITLE
Minor package updates, rename to `lotus-sdk`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .env
 node_modules
 .output
+dist
 test*
 !test/
 

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,47 @@
+# Source files
+*.ts
+tsconfig.json
+!dist/**/*.d.ts
+
+# Environment files (should never be published)
+.env
+.env.*
+*.env
+
+# Development files
+.git
+.gitignore
+.gitmodules
+.cursor/
+.output/
+node_modules/
+examples/
+test/
+tests/
+docs/
+scripts/
+
+# Test files
+*.test.js
+*.test.ts
+*.test.d.ts
+test.js
+testing.ts
+test-*.js
+test-*.d.ts
+dist/test.js
+dist/test.d.ts
+dist/testing.js
+dist/testing.d.ts
+dist/test-*.js
+dist/test-*.d.ts
+dist/eslint.config.*
+
+# Build configuration
+eslint.config.mjs
+.prettierrc.json
+.prettierignore
+
+# Documentation (keep README.md)
+TAPROOT_*.md
+VALIDATION_SUMMARY.txt

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# lotus-lib
+# lotus-sdk
 
 > **Central repository for integrating with and building for the Lotusia ecosystem**
 
@@ -81,7 +81,7 @@ A comprehensive TypeScript library providing Bitcoin-like transaction primitives
 
 ```bash
 # Install from GitHub source
-$ npm install LotusiaStewardship/lotus-lib
+$ npm install LotusiaStewardship/lotus-sdk
 ```
 
 ### Requirements
@@ -96,7 +96,7 @@ $ npm install LotusiaStewardship/lotus-lib
 ### Basic Transaction
 
 ```typescript
-import { PrivateKey, Transaction, Address } from 'lotus-lib'
+import { PrivateKey, Transaction, Address } from 'lotus-sdk'
 
 // Create key and address
 const privateKey = new PrivateKey()
@@ -117,7 +117,7 @@ console.log('Transaction:', tx.serialize())
 ### HD Wallet (BIP32/BIP39)
 
 ```typescript
-import { Mnemonic, HDPrivateKey } from 'lotus-lib'
+import { Mnemonic, HDPrivateKey } from 'lotus-sdk'
 
 // Generate mnemonic (default: 128 bits entropy = 12 words)
 const mnemonic = new Mnemonic()
@@ -141,8 +141,8 @@ const restoredHdKey = existingMnemonic.toHDPrivateKey()
 ### MuSig2 Multi-Signature
 
 ```typescript
-import { MuSig2P2PCoordinator } from 'lotus-lib/lib/p2p/musig2'
-import { PrivateKey } from 'lotus-lib'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/lib/p2p/musig2'
+import { PrivateKey } from 'lotus-sdk'
 
 // Create coordinator with P2P networking
 const coordinator = new MuSig2P2PCoordinator(
@@ -200,8 +200,8 @@ await coordinator.cleanup()
 ### SwapSig Privacy Protocol
 
 ```typescript
-import { SwapSigCoordinator } from 'lotus-lib/lib/p2p/swapsig'
-import { PrivateKey } from 'lotus-lib'
+import { SwapSigCoordinator } from 'lotus-sdk/lib/p2p/swapsig'
+import { PrivateKey } from 'lotus-sdk'
 
 // Create coordinator (extends MuSig2P2PCoordinator)
 const coordinator = new SwapSigCoordinator(
@@ -244,7 +244,7 @@ await coordinator.stop()
 ### RANK Social Ranking
 
 ```typescript
-import { toScriptRANK, toScriptRNKC, Transaction } from 'lotus-lib'
+import { toScriptRANK, toScriptRNKC, Transaction } from 'lotus-sdk'
 
 // Create positive RANK for a Twitter profile
 const rankScript = toScriptRANK(
@@ -297,7 +297,7 @@ import {
   Opcode,
   buildKeyPathTaproot,
   buildScriptPathTaproot,
-} from 'lotus-lib/lib/bitcore'
+} from 'lotus-sdk/lib/bitcore'
 
 // Create simple Taproot address (key-path only)
 const privateKey = new PrivateKey()
@@ -343,7 +343,7 @@ import {
   getBlockHash,
   getBlock,
   sendRPCRequest,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Get network info
 const networkInfo = await getNetworkInfo()
@@ -380,9 +380,9 @@ Bitcoin-like transaction primitives adapted for Lotus XPI:
 - **Encoding** - Base58, Base58Check, Varint
 
 ```typescript
-import * as Bitcore from 'lotus-lib/Bitcore'
+import * as Bitcore from 'lotus-sdk/Bitcore'
 // or
-import { PrivateKey, Transaction, Address } from 'lotus-lib'
+import { PrivateKey, Transaction, Address } from 'lotus-sdk'
 ```
 
 ### P2P Networking
@@ -395,7 +395,7 @@ libp2p-based P2P infrastructure with protocol extension system:
 - **Protocol handlers** - Extend with custom protocols
 
 ```typescript
-import { P2PCoordinator, IProtocolHandler } from 'lotus-lib/lib/p2p'
+import { P2PCoordinator, IProtocolHandler } from 'lotus-sdk/lib/p2p'
 ```
 
 See: [`lib/p2p/README.md`](lib/p2p/README.md)
@@ -410,7 +410,7 @@ Multi-signature Schnorr signatures with P2P coordination:
 - **Identity system** - Burn-based blockchain anchoring (optional)
 
 ```typescript
-import { MuSig2P2PCoordinator } from 'lotus-lib/lib/p2p/musig2'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/lib/p2p/musig2'
 ```
 
 See: [`lib/p2p/musig2/README.md`](lib/p2p/musig2/README.md)
@@ -425,7 +425,7 @@ CoinJoin-equivalent privacy protocol using MuSig2:
 - **Privacy** - Breaks on-chain transaction graph
 
 ```typescript
-import { SwapSigCoordinator } from 'lotus-lib/lib/p2p/swapsig'
+import { SwapSigCoordinator } from 'lotus-sdk/lib/p2p/swapsig'
 ```
 
 See: [`lib/p2p/swapsig/README.md`](lib/p2p/swapsig/README.md)
@@ -440,7 +440,7 @@ On-chain social ranking and reputation system:
 - **Spam prevention** - Fee-based filtering
 
 ```typescript
-import { toScriptRANK, toScriptRNKC, ScriptProcessor } from 'lotus-lib'
+import { toScriptRANK, toScriptRNKC, ScriptProcessor } from 'lotus-sdk'
 ```
 
 ### Taproot
@@ -453,7 +453,7 @@ Pay-to-Taproot support with script paths:
 - **RANK integration** - RANK protocol via Taproot
 
 ```typescript
-import { Taproot } from 'lotus-lib'
+import { Taproot } from 'lotus-sdk'
 ```
 
 ---
@@ -629,8 +629,8 @@ Contributions are welcome! Please:
 
 ```bash
 # Clone repository
-git clone https://github.com/LotusiaStewardship/lotus-lib.git
-cd lotus-lib
+git clone https://github.com/LotusiaStewardship/lotus-sdk.git
+cd lotus-sdk
 
 # Install dependencies
 npm install

--- a/docs/BURN_BASED_IDENTITY_IMPLEMENTATION.md
+++ b/docs/BURN_BASED_IDENTITY_IMPLEMENTATION.md
@@ -418,7 +418,7 @@ export * from './identity-manager.js'
 ### 1. Enable Burn-Based Identity
 
 ```typescript
-import { MuSig2P2PCoordinator } from 'lotus-lib/p2p/musig2'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/p2p/musig2'
 
 const coordinator = new MuSig2P2PCoordinator(p2pConfig, {
   // Enable burn-based identity system
@@ -514,8 +514,8 @@ Amount: >= 50 XPI for identity registration
 **Example Script**:
 
 ```typescript
-import { Script } from 'lotus-lib/bitcore/script'
-import { Transaction } from 'lotus-lib/bitcore/transaction'
+import { Script } from 'lotus-sdk/bitcore/script'
+import { Transaction } from 'lotus-sdk/bitcore/transaction'
 
 // Create OP_RETURN output with LOKAD data
 const lokadPrefix = Buffer.from([0x4c, 0x54, 0x4d, 0x53]) // "LTMS"

--- a/docs/COINJOIN_DECENTRALIZED.md
+++ b/docs/COINJOIN_DECENTRALIZED.md
@@ -1919,7 +1919,7 @@ export class P2PCoinJoinCoordinator {
 ```typescript
 // examples/coinjoin-basic.ts
 
-import { P2PCoinJoinCoordinator, PrivateKey } from 'lotus-lib'
+import { P2PCoinJoinCoordinator, PrivateKey } from 'lotus-sdk'
 
 async function basicCoinJoin() {
   // Setup
@@ -1978,7 +1978,7 @@ import {
   PrivateKey,
   musigKeyAgg,
   Address,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 async function musig2CoinJoin() {
   // Setup with MuSig2 multi-sig wallet

--- a/docs/DHT_AUTO_POPULATION_FIX.md
+++ b/docs/DHT_AUTO_POPULATION_FIX.md
@@ -61,7 +61,7 @@ const alice = new P2PCoordinator({
 For custom configurations:
 
 ```typescript
-import { passthroughMapper, removePrivateAddressesMapper } from 'lotus-lib/p2p'
+import { passthroughMapper, removePrivateAddressesMapper } from 'lotus-sdk/p2p'
 
 // Development: Allow all addresses
 const devCoordinator = new P2PCoordinator({

--- a/docs/MUSIG2_COORDINATOR_ELECTION.md
+++ b/docs/MUSIG2_COORDINATOR_ELECTION.md
@@ -69,7 +69,7 @@ In a multi-party MuSig2 signing session (e.g., 5-of-5), after all participants g
 ### Example: 5-Party Signing
 
 ```typescript
-import { electCoordinator, ElectionMethod } from 'lotus-lib/p2p/musig2/election'
+import { electCoordinator, ElectionMethod } from 'lotus-sdk/p2p/musig2/election'
 
 // All 5 participants have the same public keys
 const allPublicKeys = [alice.publicKey, bob.publicKey, charlie.publicKey, diana.publicKey, eve.publicKey]

--- a/docs/MUSIG2_ELECTION_IMPLEMENTATION_SUMMARY.md
+++ b/docs/MUSIG2_ELECTION_IMPLEMENTATION_SUMMARY.md
@@ -391,7 +391,7 @@ Test coverage:     All election methods and edge cases
 
 ## What Makes This Special
 
-1. 🌟 **First** deterministic coordinator election for MuSig2 in lotus-lib
+1. 🌟 **First** deterministic coordinator election for MuSig2 in lotus-sdk
 2. 🌟 **Production-ready** - full test coverage and working example
 3. 🌟 **Zero overhead** - no additional P2P messages
 4. 🌟 **Real-world solution** - addresses actual Bitcoin MuSig2 coordination needs

--- a/docs/MUSIG2_FAILOVER_IMPLEMENTATION.md
+++ b/docs/MUSIG2_FAILOVER_IMPLEMENTATION.md
@@ -168,7 +168,7 @@ Primary Coordinator
 ### Basic Usage
 
 ```typescript
-import { MuSig2P2PCoordinator } from 'lotus-lib/p2p/musig2'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/p2p/musig2'
 
 const coordinator = new MuSig2P2PCoordinator(
   {
@@ -568,7 +568,7 @@ Total tests:      91 tests (all passing ✅)
 ### Complete Workflow with Failover
 
 ```typescript
-import { MuSig2P2PCoordinator, ElectionMethod } from 'lotus-lib/p2p/musig2'
+import { MuSig2P2PCoordinator, ElectionMethod } from 'lotus-sdk/p2p/musig2'
 
 // Create coordinator with failover enabled
 const coordinator = new MuSig2P2PCoordinator(

--- a/docs/MUSIG2_IMPLEMENTATION_PLAN.md
+++ b/docs/MUSIG2_IMPLEMENTATION_PLAN.md
@@ -1,4 +1,4 @@
-# MuSig2 Implementation Plan for lotus-lib
+# MuSig2 Implementation Plan for lotus-sdk
 
 **Date**: October 29, 2025  
 **Status**: 📋 Planning Phase  
@@ -15,13 +15,13 @@ MuSig2 is a multi-signature scheme that enables multiple parties to create a sin
 - **Non-interactivity**: Parallel nonce exchange (2 rounds instead of 3)
 - **Security**: Provably secure under discrete log assumption
 
-This document analyzes the current taproot implementation in lotus-lib and defines the requirements for adding MuSig2 support.
+This document analyzes the current taproot implementation in lotus-sdk and defines the requirements for adding MuSig2 support.
 
 ---
 
 ## Current State Analysis
 
-### ✅ What lotus-lib Already Has
+### ✅ What lotus-sdk Already Has
 
 1. **Schnorr Signatures** (`lib/bitcore/crypto/schnorr.ts`)
    - Custom Lotus Schnorr implementation (BCH-derived)
@@ -560,7 +560,7 @@ import {
   musigPartialSign,
   musigSigAgg,
   Schnorr,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Setup
 const alice = new PrivateKey()
@@ -621,7 +621,7 @@ import {
   buildMuSigTaprootKey,
   buildScriptPathTaproot,
   MuSigSessionManager
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Setup: 3-of-3 organization multisig
 const boardMembers = [
@@ -861,7 +861,7 @@ console.log('Privacy: Looks like single-sig!')
 - Full control over implementation
 - Easy to adapt to Lotus Schnorr
 - No C++ dependencies
-- Native to lotus-lib
+- Native to lotus-sdk
 
 **Cons**:
 
@@ -892,7 +892,7 @@ console.log('Privacy: Looks like single-sig!')
 
 ### Required
 
-- Existing lotus-lib cryptographic primitives
+- Existing lotus-sdk cryptographic primitives
 - BN.js for big number arithmetic
 - Existing Point/PublicKey classes
 
@@ -934,7 +934,7 @@ console.log('Privacy: Looks like single-sig!')
 
 ## Conclusion
 
-Implementing MuSig2 for lotus-lib is feasible and valuable:
+Implementing MuSig2 for lotus-sdk is feasible and valuable:
 
 ### ✅ Feasibility
 

--- a/docs/MUSIG2_MESSAGE_REPLAY_PROTECTION.md
+++ b/docs/MUSIG2_MESSAGE_REPLAY_PROTECTION.md
@@ -586,8 +586,8 @@ enforcement tests - they confirm the validation is working correctly.
 ### Standard 2-of-2 Signing
 
 ```typescript
-import { MuSig2P2PCoordinator } from 'lotus-lib/lib/p2p/musig2'
-import { PrivateKey } from 'lotus-lib/lib/bitcore'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/lib/p2p/musig2'
+import { PrivateKey } from 'lotus-sdk/lib/bitcore'
 
 // Create coordinators with replay protection (default)
 const aliceCoord = new MuSig2P2PCoordinator({

--- a/docs/MUSIG2_P2P_ANALYSIS.md
+++ b/docs/MUSIG2_P2P_ANALYSIS.md
@@ -22,7 +22,7 @@
 
 ## Executive Summary
 
-The MuSig2 P2P implementation in `lotus-lib/lib/p2p/musig2/` is a **well-architected, production-ready extension** of the base P2P infrastructure. This analysis validates the implementation against the MuSig2 protocol specification (BIP327) and assesses its integration with the existing P2P coordination layer.
+The MuSig2 P2P implementation in `lotus-sdk/lib/p2p/musig2/` is a **well-architected, production-ready extension** of the base P2P infrastructure. This analysis validates the implementation against the MuSig2 protocol specification (BIP327) and assesses its integration with the existing P2P coordination layer.
 
 ### Key Findings
 

--- a/docs/MUSIG2_P2P_COORDINATION.md
+++ b/docs/MUSIG2_P2P_COORDINATION.md
@@ -24,7 +24,7 @@
 
 ## Overview
 
-This document describes the **three-phase architecture** for MuSig2 P2P coordination in lotus-lib. The implementation solves the peer discovery chicken-and-egg problem through a phased approach.
+This document describes the **three-phase architecture** for MuSig2 P2P coordination in lotus-sdk. The implementation solves the peer discovery chicken-and-egg problem through a phased approach.
 
 ### Current State
 
@@ -138,7 +138,7 @@ await coordinator.joinSigningRequest(requestId, myPrivateKey)
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│                     lotus-lib (Current)                         │
+│                     lotus-sdk (Current)                         │
 │  ┌────────────────────────────────────────────────────────┐    │
 │  │ MuSig2 Core (crypto/musig2.ts) ✅                      │    │
 │  │ MuSig2 Session Manager (crypto/musig2-session.ts) ✅   │    │
@@ -1537,7 +1537,7 @@ export interface P2PCoordinatorConfig {
 ### Usage Example
 
 ```typescript
-import { P2PCoordinator, PrivateKey } from 'lotus-lib'
+import { P2PCoordinator, PrivateKey } from 'lotus-sdk'
 
 // Alice: Create and announce session
 const alice = new PrivateKey()
@@ -1783,7 +1783,7 @@ describe('Performance', () => {
 ```json
 {
   "dependencies": {
-    // Existing lotus-lib dependencies...
+    // Existing lotus-sdk dependencies...
 
     // P2P networking (choose one approach):
 

--- a/docs/MUSIG2_P2P_PHASE3_COMPLETE.md
+++ b/docs/MUSIG2_P2P_PHASE3_COMPLETE.md
@@ -390,8 +390,8 @@ Total: ~3,394 lines of implementation, tests, and examples
 ### Basic 2-of-2 Signing
 
 ```typescript
-import { P2PCoordinator } from 'lotus-lib/p2p'
-import { MuSig2P2PCoordinator } from 'lotus-lib/p2p/musig2'
+import { P2PCoordinator } from 'lotus-sdk/p2p'
+import { MuSig2P2PCoordinator } from 'lotus-sdk/p2p/musig2'
 
 // Step 1: Create P2P coordinators
 const aliceP2P = new P2PCoordinator({
@@ -784,7 +784,7 @@ const musig2 = new MuSig2P2PCoordinator({
 No new dependencies added. Uses existing:
 
 - `libp2p` ecosystem (Phase 1)
-- `lotus-lib` crypto primitives (MuSig2, Point, BN)
+- `lotus-sdk` crypto primitives (MuSig2, Point, BN)
 - `node:test` for testing
 - `node:events` for EventEmitter
 
@@ -853,7 +853,7 @@ Phase 3 implementation is **COMPLETE AND FULLY OPERATIONAL** ✅. The MuSig2 P2P
 
 ### What Makes This Special
 
-- 🌟 **First** MuSig2 P2P implementation in lotus-lib
+- 🌟 **First** MuSig2 P2P implementation in lotus-sdk
 - 🌟 **Generic** - extends proven P2P infrastructure
 - 🌟 **Type-safe** - proper TypeScript throughout
 - 🌟 **Production-grade** - using battle-tested libp2p

--- a/docs/MUSIG2_QUICK_REFERENCE.md
+++ b/docs/MUSIG2_QUICK_REFERENCE.md
@@ -1,4 +1,4 @@
-# MuSig2 Quick Reference for lotus-lib
+# MuSig2 Quick Reference for lotus-sdk
 
 **TL;DR**: MuSig2 implementation with P2P three-phase coordination architecture + GossipSub event-driven discovery for real-time peer discovery and dynamic session building.
 
@@ -12,7 +12,7 @@
 ### Quick Start
 
 ```typescript
-import { MuSig2P2PCoordinator, TransactionType } from 'lotus-lib/p2p/musig2'
+import { MuSig2P2PCoordinator, TransactionType } from 'lotus-sdk/p2p/musig2'
 
 // Create coordinator with GossipSub
 const coordinator = new MuSig2P2PCoordinator({
@@ -203,7 +203,7 @@ if (!R.hasSquare()) {
 ## File Structure
 
 ```
-lotus-lib/
+lotus-sdk/
 ├── lib/bitcore/
 │   ├── crypto/
 │   │   ├── musig2.ts          ← NEW: Core MuSig2 functions
@@ -238,7 +238,7 @@ lotus-lib/
 | Taproot Integration | tweakPublicKey()  | ✅ Available     |
 | Transaction Signing | TaprootInput      | ✅ Available     |
 
-**Summary**: 90% of dependencies already exist in lotus-lib!
+**Summary**: 90% of dependencies already exist in lotus-sdk!
 
 ---
 
@@ -305,7 +305,7 @@ lotus-lib/
 
 ## Code Size Comparison
 
-**Existing lotus-lib Taproot**:
+**Existing lotus-sdk Taproot**:
 
 - `taproot.ts`: 542 lines
 - `taproot-input.ts`: 222 lines

--- a/docs/MUSIG2_START_HERE.md
+++ b/docs/MUSIG2_START_HERE.md
@@ -1,4 +1,4 @@
-# MuSig2 for lotus-lib - Start Here
+# MuSig2 for lotus-sdk - Start Here
 
 **Welcome!** This guide will help you navigate the MuSig2 implementation documentation and code.
 
@@ -431,7 +431,7 @@ Use this checklist to track your progress:
 
 - Review `MUSIG2_IMPLEMENTATION_PLAN.md`
 - Check starter code comments
-- Study existing lotus-lib patterns
+- Study existing lotus-sdk patterns
 
 ---
 

--- a/docs/NFT.md
+++ b/docs/NFT.md
@@ -447,7 +447,7 @@ Lotus NFTs can be created using either:
 ### Basic NFT Creation (Using NFT Class)
 
 ```typescript
-import { PrivateKey, NFT } from 'lotus-lib'
+import { PrivateKey, NFT } from 'lotus-sdk'
 
 // Create owner key
 const ownerKey = new PrivateKey()
@@ -480,7 +480,7 @@ console.log('Valid:', nft.verifyMetadata())
 ### Basic NFT Creation (Using NFTUtil)
 
 ```typescript
-import { PrivateKey, NFTUtil } from 'lotus-lib'
+import { PrivateKey, NFTUtil } from 'lotus-sdk'
 
 const ownerKey = new PrivateKey()
 
@@ -602,7 +602,7 @@ batchTx.sign(ownerKey)
 ### NFT with Trading Script Tree
 
 ```typescript
-import { Script, Opcode, TapNode } from 'lotus-lib'
+import { Script, Opcode, TapNode } from 'lotus-sdk'
 
 const seller = new PrivateKey()
 const buyer = new PrivateKey()
@@ -1196,7 +1196,7 @@ npm test -- nft
 
 - [Lotus Taproot Specification](https://lotusia.org/docs/specs/script/taproot)
 - [Taproot NFT Examples](https://lotusia.org/docs/specs/script/examples/taproot-nfts)
-- [lotus-lib Taproot Implementation](./TAPROOT_IMPLEMENTATION.md)
+- [lotus-sdk Taproot Implementation](./TAPROOT_IMPLEMENTATION.md)
 - [OpenSea Metadata Standards](https://docs.opensea.io/docs/metadata-standards)
 
 ---
@@ -1210,5 +1210,5 @@ npm test -- nft
 ---
 
 **Last Updated**: October 28, 2025  
-**Implementation**: `lotus-lib/lib/bitcore/nft.ts`  
-**Examples**: `lotus-lib/examples/nft-examples.ts`
+**Implementation**: `lotus-sdk/lib/bitcore/nft.ts`  
+**Examples**: `lotus-sdk/examples/nft-examples.ts`

--- a/docs/P2P_CORE_SECURITY.md
+++ b/docs/P2P_CORE_SECURITY.md
@@ -485,7 +485,7 @@ coreSecurity.on('peer:warned', (peerId, count, reason) => {
 ### Core Security Limits
 
 ```typescript
-import { CORE_P2P_SECURITY_LIMITS } from 'lotus-lib/p2p'
+import { CORE_P2P_SECURITY_LIMITS } from 'lotus-sdk/p2p'
 
 // Read limits
 console.log('Max message size:', CORE_P2P_SECURITY_LIMITS.MAX_P2P_MESSAGE_SIZE)

--- a/docs/P2P_DHT_ARCHITECTURE.md
+++ b/docs/P2P_DHT_ARCHITECTURE.md
@@ -23,7 +23,7 @@
 
 ## Overview
 
-The **Distributed Hash Table (DHT)** in lotus-lib provides the foundational infrastructure for decentralized peer-to-peer coordination. This document explains how the DHT is constructed, what it looks like both conceptually and technically, and how individual nodes communicate to facilitate MuSig2 multi-signature coordination.
+The **Distributed Hash Table (DHT)** in lotus-sdk provides the foundational infrastructure for decentralized peer-to-peer coordination. This document explains how the DHT is constructed, what it looks like both conceptually and technically, and how individual nodes communicate to facilitate MuSig2 multi-signature coordination.
 
 **Key Components:**
 
@@ -137,7 +137,7 @@ GET(key):
 
 ### Architecture
 
-lotus-lib uses `@libp2p/kad-dht`, the standard Kademlia DHT implementation for libp2p:
+lotus-sdk uses `@libp2p/kad-dht`, the standard Kademlia DHT implementation for libp2p:
 
 ```typescript
 import { kadDHT, KadDHT } from '@libp2p/kad-dht'

--- a/docs/P2P_INFRASTRUCTURE.md
+++ b/docs/P2P_INFRASTRUCTURE.md
@@ -9,7 +9,7 @@
 
 ## Executive Summary
 
-The **P2P Coordination Layer** is a generalized peer-to-peer networking infrastructure for lotus-lib. It provides the foundation for decentralized coordination between wallets and applications without requiring central servers.
+The **P2P Coordination Layer** is a generalized peer-to-peer networking infrastructure for lotus-sdk. It provides the foundation for decentralized coordination between wallets and applications without requiring central servers.
 
 ### What Was Built
 
@@ -120,7 +120,7 @@ P2PCoordinator
 **Usage**:
 
 ```typescript
-import { P2PCoordinator } from 'lotus-lib/p2p'
+import { P2PCoordinator } from 'lotus-sdk/p2p'
 
 const coordinator = new P2PCoordinator({
   peerId: 'unique-peer-id',
@@ -330,7 +330,7 @@ import {
   P2PMessage,
   PeerInfo,
   P2PCoordinator,
-} from 'lotus-lib/p2p'
+} from 'lotus-sdk/p2p'
 
 class MyProtocolHandler implements IProtocolHandler {
   readonly protocolName = 'my-protocol'
@@ -458,13 +458,13 @@ class CoinJoinP2PHandler implements IProtocolHandler {
 # Install dependencies
 npm install
 
-# The P2P module is included in lotus-lib
+# The P2P module is included in lotus-sdk
 ```
 
 ### Basic Setup
 
 ```typescript
-import { P2PCoordinator } from 'lotus-lib/p2p'
+import { P2PCoordinator } from 'lotus-sdk/p2p'
 
 // Create coordinator
 const coordinator = new P2PCoordinator({
@@ -486,7 +486,7 @@ coordinator.on('message', (message, from) => {
 ### Connect to Peers
 
 ```typescript
-import { PeerInfo, PeerState } from 'lotus-lib/p2p'
+import { PeerInfo, PeerState } from 'lotus-sdk/p2p'
 
 const peer: PeerInfo = {
   peerId: 'other-peer-123',
@@ -799,7 +799,7 @@ See [MUSIG2_P2P_COORDINATION.md](./MUSIG2_P2P_COORDINATION.md) for comprehensive
 ### Example 1: Basic P2P Communication
 
 ```typescript
-import { P2PCoordinator, PeerInfo, PeerState } from 'lotus-lib/p2p'
+import { P2PCoordinator, PeerInfo, PeerState } from 'lotus-sdk/p2p'
 
 const coordinator = new P2PCoordinator({
   peerId: 'alice',
@@ -851,7 +851,7 @@ console.log('Available rounds:', rounds)
 ### Example 3: Protocol Handler
 
 ```typescript
-import { IProtocolHandler } from 'lotus-lib/p2p'
+import { IProtocolHandler } from 'lotus-sdk/p2p'
 
 class SimpleProtocol implements IProtocolHandler {
   readonly protocolName = 'simple'
@@ -956,11 +956,11 @@ docs/
 
 ---
 
-## Integration with lotus-lib
+## Integration with lotus-sdk
 
 ### Current Integration
 
-The P2P module is **standalone** and doesn't depend on other lotus-lib components (except crypto utilities).
+The P2P module is **standalone** and doesn't depend on other lotus-sdk components (except crypto utilities).
 
 ```
 lib/
@@ -1344,7 +1344,7 @@ const discovery = new ResourceDiscovery(dht, peerId)
 
 ## Conclusion
 
-Phase 1 of the P2P infrastructure is **complete and functional**. It provides a solid foundation for building decentralized protocols on lotus-lib.
+Phase 1 of the P2P infrastructure is **complete and functional**. It provides a solid foundation for building decentralized protocols on lotus-sdk.
 
 ### What's Ready
 

--- a/docs/P2P_PHASE1_COMPLETE.md
+++ b/docs/P2P_PHASE1_COMPLETE.md
@@ -326,7 +326,7 @@ services: {
 ### Basic P2P Node
 
 ```typescript
-import { P2PCoordinator } from 'lotus-lib/p2p'
+import { P2PCoordinator } from 'lotus-sdk/p2p'
 
 // Create and start node
 const coordinator = new P2PCoordinator({
@@ -357,7 +357,7 @@ await coordinator.stop()
 ### Protocol Extension
 
 ```typescript
-import { IProtocolHandler, P2PMessage, PeerInfo } from 'lotus-lib/p2p'
+import { IProtocolHandler, P2PMessage, PeerInfo } from 'lotus-sdk/p2p'
 
 class MuSig2Handler implements IProtocolHandler {
   readonly protocolName = 'musig2'
@@ -568,7 +568,7 @@ await coordinator.connectToPeer('/ip4/host/tcp/port/p2p/peerId')
    ```bash
    nvm install 22
    nvm use 22
-   cd /home/matthew/Documents/Code/lotus-lib
+   cd /home/matthew/Documents/Code/lotus-sdk
    rm -rf node_modules package-lock.json
    npm install
    ```
@@ -684,7 +684,7 @@ Total:              10,314 lines
 
 ## Conclusion
 
-Phase 1 implementation is **COMPLETE AND FULLY OPERATIONAL** ✅. The libp2p integration provides a **battle-tested, production-grade foundation** for building decentralized protocols on lotus-lib.
+Phase 1 implementation is **COMPLETE AND FULLY OPERATIONAL** ✅. The libp2p integration provides a **battle-tested, production-grade foundation** for building decentralized protocols on lotus-sdk.
 
 ### Key Takeaways
 
@@ -697,7 +697,7 @@ Phase 1 implementation is **COMPLETE AND FULLY OPERATIONAL** ✅. The libp2p int
 
 ### What Makes This Special
 
-- 🌟 **First** full libp2p integration in lotus-lib
+- 🌟 **First** full libp2p integration in lotus-sdk
 - 🌟 **Generic** - not MuSig2-specific, any protocol can use it
 - 🌟 **Type-safe** - proper TypeScript throughout with native types
 - 🌟 **Production-grade** - using proven P2P stack (IPFS, Filecoin, Ethereum 2.0)

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_CHANGES.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_CHANGES.md
@@ -351,7 +351,7 @@ Error: SIGHASH_LOTUS requires spent outputs for all inputs (ensure all inputs ha
 
 ### Test Against lotusd
 
-- Generate transactions in lotus-lib
+- Generate transactions in lotus-sdk
 - Compare sighash output with lotusd
 - Verify transactions validate in lotusd
 - Test on Lotus testnet

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_CORRECT_USAGE.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_CORRECT_USAGE.md
@@ -147,7 +147,7 @@ Therefore: **SIGHASH_LOTUS automatically includes SIGHASH_FORKID**.
 ### Example 1: Single Input, Single Output
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const utxo = {
@@ -324,7 +324,7 @@ If you're updating code that incorrectly used SIGHASH_LOTUS:
 ## Testing Your Implementation
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 // Create test transaction
 const privateKey = new PrivateKey()

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_EXAMPLES.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_EXAMPLES.md
@@ -1,6 +1,6 @@
 # SIGHASH_LOTUS Usage Examples
 
-Complete examples demonstrating how to use SIGHASH_LOTUS in lotus-lib.
+Complete examples demonstrating how to use SIGHASH_LOTUS in lotus-sdk.
 
 ---
 
@@ -21,7 +21,7 @@ Complete examples demonstrating how to use SIGHASH_LOTUS in lotus-lib.
 ### Simple P2PKH Transaction with SIGHASH_LOTUS
 
 ```typescript
-import { Transaction, PrivateKey, Signature, Address } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature, Address } from 'lotus-sdk'
 
 // Create private key and address
 const privateKey = new PrivateKey()
@@ -57,7 +57,7 @@ console.log('Spent outputs:', tx.spentOutputs)
 ### Transaction with Multiple UTXOs
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -110,7 +110,7 @@ console.log('Transaction size:', tx.toBuffer().length, 'bytes')
 Signs only the input and corresponding output at the same index.
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -134,7 +134,7 @@ console.log('Only input 0 and output 0 are committed')
 Signs only one input, allows others to add more inputs.
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -163,7 +163,7 @@ console.log('Others can add more inputs to this transaction')
 Schnorr signatures are smaller and more efficient than ECDSA.
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -188,7 +188,7 @@ console.log('Signature length:', sig.length, 'bytes')
 ### Multiple Keys with Schnorr
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey1 = new PrivateKey()
 const privateKey2 = new PrivateKey()
@@ -237,7 +237,7 @@ console.log('All inputs signed with Schnorr + SIGHASH_LOTUS')
 ### Verify SIGHASH_LOTUS Signatures
 
 ```typescript
-import { Transaction, verify } from 'lotus-lib'
+import { Transaction, verify } from 'lotus-sdk'
 
 // Parse a signed transaction
 const tx = Transaction.fromString(signedTxHex)
@@ -280,7 +280,7 @@ for (let i = 0; i < tx.inputs.length; i++) {
 SIGHASH_LOTUS requires output information for all inputs.
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -337,7 +337,7 @@ console.log('Success! All outputs tracked:', tx.spentOutputs?.length)
 ### Before (SIGHASH_FORKID)
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -353,7 +353,7 @@ console.log('Uses BIP143 sighash algorithm')
 ### After (SIGHASH_LOTUS)
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 
@@ -390,7 +390,7 @@ console.log('Better scaling and validation efficiency')
 ### View Spent Output Details
 
 ```typescript
-import { Transaction } from 'lotus-lib'
+import { Transaction } from 'lotus-sdk'
 
 const tx = new Transaction()
   .from(utxo1)
@@ -470,7 +470,7 @@ const tx = new Transaction()
 ### 4. Handle Errors Gracefully
 
 ```typescript
-import { Transaction, Signature } from 'lotus-lib'
+import { Transaction, Signature } from 'lotus-sdk'
 
 function signWithLotus(tx: Transaction, privateKey: PrivateKey): Transaction {
   try {
@@ -502,7 +502,7 @@ import {
   Address,
   Script,
   UnspentOutput,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Setup
 const privateKey = new PrivateKey()
@@ -557,7 +557,7 @@ console.log(`  Valid: ${isValid === true ? '✓' : '✗ ' + isValid}`)
 
 ## Summary
 
-SIGHASH_LOTUS is now fully integrated into lotus-lib:
+SIGHASH_LOTUS is now fully integrated into lotus-sdk:
 
 - ✅ Use `Transaction.sign()` with `SIGHASH_LOTUS` flag
 - ✅ Automatically tracks spent outputs via `.from()`

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_IMPLEMENTATION.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_IMPLEMENTATION.md
@@ -173,7 +173,7 @@ function sighashForLotus(
 ### Basic SIGHASH_LOTUS Signing (High-Level API)
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 // Create transaction using .from() to automatically attach output info
 const tx = new Transaction()
@@ -197,7 +197,7 @@ console.log(tx.spentOutputs) // [Output, Output]
 ### Standard Signing (Default SIGHASH_FORKID)
 
 ```typescript
-import { Transaction, PrivateKey } from 'lotus-lib'
+import { Transaction, PrivateKey } from 'lotus-sdk'
 
 // Standard signing uses SIGHASH_FORKID by default
 const tx = new Transaction().from(utxo).to(address, amount).sign(privateKey) // Uses SIGHASH_ALL | SIGHASH_FORKID by default
@@ -388,7 +388,7 @@ Validated against:
 ### Integration Tests
 
 1. **Cross-Validation with lotusd**
-   - Generate sighash in lotus-lib
+   - Generate sighash in lotus-sdk
    - Compare with lotusd output
    - Must match exactly
 
@@ -716,7 +716,7 @@ tx.from(utxo).to(address, amount).sign(privateKey)
 ✅ **Now Available via High-Level API!**
 
 ```typescript
-import { Transaction, Signature } from 'lotus-lib'
+import { Transaction, Signature } from 'lotus-sdk'
 
 // Simply use .from() to automatically attach output info
 const tx = new Transaction()

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_PHASEOUT.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_PHASEOUT.md
@@ -170,7 +170,7 @@ SCRIPT_DISABLE_TAPROOT_SIGHASH_LOTUS = (1U << 1),
 
 ---
 
-## Impact on lotus-lib
+## Impact on lotus-sdk
 
 ### Current Implementation Status
 
@@ -208,7 +208,7 @@ SIGHASH_LOTUS likely had a brief window of support:
 ### ✅ Use SIGHASH_FORKID (Standard)
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 const tx = new Transaction().from(utxo).to(address, amount).sign(privateKey) // Default: SIGHASH_ALL | SIGHASH_FORKID
 
@@ -245,7 +245,7 @@ Explicitly tests the Taproot (and by extension SIGHASH_LOTUS) phase-out.
 
 ## Recommendation
 
-### For lotus-lib
+### For lotus-sdk
 
 1. **Mark SIGHASH_LOTUS as deprecated**
 2. **Remove or comment out SIGHASH_LOTUS code** (or clearly mark as historical)

--- a/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_QUICKSTART.md
+++ b/docs/SIGHASH_LOTUS/SIGHASH_LOTUS_QUICKSTART.md
@@ -1,6 +1,6 @@
 # SIGHASH_LOTUS Quick Start Guide
 
-Fast-track guide to using SIGHASH_LOTUS in lotus-lib.
+Fast-track guide to using SIGHASH_LOTUS in lotus-sdk.
 
 ---
 
@@ -18,9 +18,9 @@ SIGHASH_LOTUS is Lotus's advanced signature hash algorithm that uses merkle tree
 ## Installation
 
 ```bash
-npm install lotus-lib
+npm install lotus-sdk
 # or
-yarn add lotus-lib
+yarn add lotus-sdk
 ```
 
 ---
@@ -30,7 +30,7 @@ yarn add lotus-lib
 ### 1. Import Required Classes
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 ```
 
 ### 2. Create and Sign Transaction
@@ -195,7 +195,7 @@ if (tx.spentOutputs) {
 ## Error Handling
 
 ```typescript
-import { Transaction, Signature } from 'lotus-lib'
+import { Transaction, Signature } from 'lotus-sdk'
 
 try {
   tx.sign(
@@ -240,7 +240,7 @@ const tx = new Transaction()
 ## Complete Example
 
 ```typescript
-import { Transaction, PrivateKey, Signature, Address, Script } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature, Address, Script } from 'lotus-sdk'
 
 // Setup
 const privateKey = new PrivateKey('your_private_key_wif')
@@ -330,7 +330,7 @@ SIGHASH_ALL | SIGHASH_FORKID // Standard (default)
 ## Testing
 
 ```typescript
-import { Transaction, PrivateKey, Signature } from 'lotus-lib'
+import { Transaction, PrivateKey, Signature } from 'lotus-sdk'
 
 describe('SIGHASH_LOTUS', () => {
   it('should sign transaction with LOTUS', () => {
@@ -419,4 +419,4 @@ tx.from(utxo)
 
 **Implementation Status**: ✅ Production Ready  
 **Date**: October 28, 2025  
-**lotus-lib version**: Latest
+**lotus-sdk version**: Latest

--- a/docs/taproot/api-reference.md
+++ b/docs/taproot/api-reference.md
@@ -1,6 +1,6 @@
 # Taproot API Reference
 
-**Your Complete Guide to Taproot in lotus-lib**
+**Your Complete Guide to Taproot in lotus-sdk**
 
 Welcome! This is your one-stop reference for building with Taproot on Lotus. Whether you're creating NFTs, implementing multi-sig wallets, or building advanced smart contracts, you'll find everything you need here.
 
@@ -40,7 +40,7 @@ Welcome! This is your one-stop reference for building with Taproot on Lotus. Whe
 ### Installation
 
 ```bash
-npm install lotus-lib
+npm install lotus-sdk
 ```
 
 ### 30-Second Example
@@ -51,7 +51,7 @@ import {
   PrivateKey,
   Signature,
   buildKeyPathTaproot,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Create Taproot output
 const privateKey = new PrivateKey()
@@ -108,7 +108,7 @@ function buildKeyPathTaproot(internalPubKey: PublicKey, state?: Buffer): Script
 **Example:**
 
 ```typescript
-import { buildKeyPathTaproot, PrivateKey } from 'lotus-lib'
+import { buildKeyPathTaproot, PrivateKey } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const taprootScript = buildKeyPathTaproot(privateKey.publicKey)
@@ -155,7 +155,7 @@ function buildScriptPathTaproot(
 **Example:**
 
 ```typescript
-import { buildScriptPathTaproot, Script, Opcode } from 'lotus-lib'
+import { buildScriptPathTaproot, Script, Opcode } from 'lotus-sdk'
 
 // Create timelock script
 const timelockScript = new Script()
@@ -225,7 +225,7 @@ function buildPayToTaproot(commitment: PublicKey, state?: Buffer): Script
 **Example:**
 
 ```typescript
-import { buildPayToTaproot, tweakPublicKey } from 'lotus-lib'
+import { buildPayToTaproot, tweakPublicKey } from 'lotus-sdk'
 
 const internalPubKey = privateKey.publicKey
 const merkleRoot = Buffer.alloc(32)
@@ -273,7 +273,7 @@ commitment = internal_pubkey + tweak * G
 **Example:**
 
 ```typescript
-import { tweakPublicKey, PrivateKey } from 'lotus-lib'
+import { tweakPublicKey, PrivateKey } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const internalPubKey = privateKey.publicKey
@@ -315,7 +315,7 @@ tweaked_privkey = (internal_privkey + tweak) mod n
 **Example:**
 
 ```typescript
-import { tweakPrivateKey, PrivateKey } from 'lotus-lib'
+import { tweakPrivateKey, PrivateKey } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const merkleRoot = Buffer.alloc(32) // Key-only
@@ -378,7 +378,7 @@ tagged_hash = SHA256(tag_hash || tag_hash || data)
 **Example:**
 
 ```typescript
-import { taggedHash } from 'lotus-lib'
+import { taggedHash } from 'lotus-sdk'
 
 const data = Buffer.from('hello taproot', 'utf8')
 const hash = taggedHash('CustomTag', data)
@@ -418,7 +418,7 @@ tapleaf_hash = tagged_hash("TapLeaf", leaf_version || compact_size(script) || sc
 **Example:**
 
 ```typescript
-import { calculateTapLeaf, Script, Opcode } from 'lotus-lib'
+import { calculateTapLeaf, Script, Opcode } from 'lotus-sdk'
 
 const script = new Script().add(publicKey.toBuffer()).add(Opcode.OP_CHECKSIG)
 
@@ -454,7 +454,7 @@ tapbranch_hash = tagged_hash("TapBranch", sorted_left || sorted_right)
 **Example:**
 
 ```typescript
-import { calculateTapBranch, calculateTapLeaf } from 'lotus-lib'
+import { calculateTapBranch, calculateTapLeaf } from 'lotus-sdk'
 
 const leaf1Hash = calculateTapLeaf(script1)
 const leaf2Hash = calculateTapLeaf(script2)
@@ -489,7 +489,7 @@ interface TapTreeBuildResult {
 **Example:**
 
 ```typescript
-import { buildTapTree } from 'lotus-lib'
+import { buildTapTree } from 'lotus-sdk'
 
 const tree = {
   left: { script: script1 },
@@ -580,7 +580,7 @@ Bytes 33+:  merkle path (32 bytes per node, up to 128 nodes max)
 **Example:**
 
 ```typescript
-import { createControlBlock } from 'lotus-lib'
+import { createControlBlock } from 'lotus-sdk'
 
 const tree = {
   left: { script: script1 },
@@ -629,7 +629,7 @@ function isPayToTaproot(script: Script): boolean
 **Example:**
 
 ```typescript
-import { isPayToTaproot, buildKeyPathTaproot } from 'lotus-lib'
+import { isPayToTaproot, buildKeyPathTaproot } from 'lotus-sdk'
 
 const taprootScript = buildKeyPathTaproot(publicKey)
 const regularScript = Script.buildPublicKeyHashOut(address)
@@ -659,7 +659,7 @@ function extractTaprootCommitment(script: Script): PublicKey
 **Example:**
 
 ```typescript
-import { extractTaprootCommitment, buildKeyPathTaproot } from 'lotus-lib'
+import { extractTaprootCommitment, buildKeyPathTaproot } from 'lotus-sdk'
 
 const taprootScript = buildKeyPathTaproot(publicKey)
 const commitment = extractTaprootCommitment(taprootScript)
@@ -692,7 +692,7 @@ function extractTaprootState(script: Script): Buffer | null
 **Example:**
 
 ```typescript
-import { extractTaprootState, buildKeyPathTaproot } from 'lotus-lib'
+import { extractTaprootState, buildKeyPathTaproot } from 'lotus-sdk'
 
 // Script with state
 const metadataHash = Buffer.alloc(32, 0xff)
@@ -759,7 +759,7 @@ import {
   verifyTaprootCommitment,
   tweakPublicKey,
   extractTaprootCommitment,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 const merkleRoot = Buffer.alloc(32)
 const commitment = tweakPublicKey(internalPubKey, merkleRoot)
@@ -815,7 +815,7 @@ function verifyTaprootScriptPath(
 **Example:**
 
 ```typescript
-import { verifyTaprootScriptPath, createControlBlock } from 'lotus-lib'
+import { verifyTaprootScriptPath, createControlBlock } from 'lotus-sdk'
 
 // Extract data from control block
 const controlBlock = createControlBlock(internalPubKey, 0, tree)
@@ -880,7 +880,7 @@ interface TaprootVerifyResult {
 **Example:**
 
 ```typescript
-import { verifyTaprootSpend } from 'lotus-lib'
+import { verifyTaprootSpend } from 'lotus-sdk'
 
 // For key path
 const stack = [signatureBuffer] // 65 bytes
@@ -941,7 +941,7 @@ new NFT(config: {
 **Example:**
 
 ```typescript
-import { NFT, PrivateKey } from 'lotus-lib'
+import { NFT, PrivateKey } from 'lotus-sdk'
 
 const ownerKey = new PrivateKey()
 
@@ -1217,7 +1217,7 @@ static hashMetadata(metadata: NFTMetadata): Buffer
 **Example:**
 
 ```typescript
-import { NFTUtil } from 'lotus-lib'
+import { NFTUtil } from 'lotus-sdk'
 
 const metadata = {
   name: 'My NFT',
@@ -1455,7 +1455,7 @@ interface MuSig2SignerConfig {
 **Example - Simple 2-of-2 Signing:**
 
 ```typescript
-import { MuSig2Signer, PrivateKey } from 'lotus-lib'
+import { MuSig2Signer, PrivateKey } from 'lotus-sdk'
 
 const alice = new PrivateKey()
 const bob = new PrivateKey()
@@ -1863,7 +1863,7 @@ getSessionStatus(session: MuSigSession): {
 **Example - Session-Based Signing:**
 
 ```typescript
-import { MuSigSessionManager, MuSigSessionPhase } from 'lotus-lib'
+import { MuSigSessionManager, MuSigSessionPhase } from 'lotus-sdk'
 
 const manager = new MuSigSessionManager()
 
@@ -2098,7 +2098,7 @@ function buildMuSigTaprootKey(
 **Example:**
 
 ```typescript
-import { buildMuSigTaprootKey } from 'lotus-lib'
+import { buildMuSigTaprootKey } from 'lotus-sdk'
 
 const result = buildMuSigTaprootKey([
   alice.publicKey,
@@ -2511,7 +2511,7 @@ import {
   PrivateKey,
   Signature,
   buildKeyPathTaproot,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // Create Taproot output
 const privateKey = new PrivateKey()
@@ -2551,7 +2551,7 @@ console.log('Valid:', spendingTx.verify())
 ### Creating Taproot Addresses
 
 ```typescript
-import { Address, tweakPublicKey } from 'lotus-lib'
+import { Address, tweakPublicKey } from 'lotus-sdk'
 
 // Method 1: From commitment
 const commitment = tweakPublicKey(publicKey, Buffer.alloc(32))
@@ -2611,7 +2611,7 @@ const outputData = {
 ### Converting Back to Script
 
 ```typescript
-import { Script, Address } from 'lotus-lib'
+import { Script, Address } from 'lotus-sdk'
 
 const address = Address.fromString('lotus_X...') // P2TR address
 const script = Script.fromAddress(address)
@@ -2657,7 +2657,7 @@ if (address.isPayToScriptHash()) {
 **Use case:** Maximum privacy for single-signature wallets
 
 ```typescript
-import { PrivateKey, buildKeyPathTaproot, Transaction } from 'lotus-lib'
+import { PrivateKey, buildKeyPathTaproot, Transaction } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const taprootScript = buildKeyPathTaproot(privateKey.publicKey)
@@ -2673,7 +2673,7 @@ const taprootScript = buildKeyPathTaproot(privateKey.publicKey)
 **Use case:** Prevent vote manipulation by locking funds
 
 ```typescript
-import { Script, Opcode, buildScriptPathTaproot } from 'lotus-lib'
+import { Script, Opcode, buildScriptPathTaproot } from 'lotus-sdk'
 
 const voterKey = new PrivateKey()
 const unlockHeight = currentHeight + 720 // 24 hours
@@ -2747,7 +2747,7 @@ const tx = new Transaction()
 **Use case:** Private multi-sig (looks like single-sig)
 
 ```typescript
-import { MuSig2Signer, Transaction, Signature } from 'lotus-lib'
+import { MuSig2Signer, Transaction, Signature } from 'lotus-sdk'
 
 // Setup: 3-of-3 MuSig2 (all must sign)
 const alice = new PrivateKey()
@@ -2864,7 +2864,7 @@ await broadcast(tx.serialize())
 **Use case:** Provably unique digital assets
 
 ```typescript
-import { NFT, Hash } from 'lotus-lib'
+import { NFT, Hash } from 'lotus-sdk'
 
 const metadata = {
   name: 'Lotus Genesis NFT',
@@ -2904,7 +2904,7 @@ await broadcast(transferTx.serialize())
 **Use case:** Payment channels with HTLC
 
 ```typescript
-import { Script, Opcode, Hash } from 'lotus-lib'
+import { Script, Opcode, Hash } from 'lotus-sdk'
 
 const alice = new PrivateKey()
 const bob = new PrivateKey()
@@ -2949,7 +2949,7 @@ console.log('Bob can refund after timeout')
 **Use case:** Multi-sig governance with privacy
 
 ```typescript
-import { buildMuSigTaprootKey } from 'lotus-lib'
+import { buildMuSigTaprootKey } from 'lotus-sdk'
 
 // 3-of-5 board members
 const boardMembers = [
@@ -3253,7 +3253,7 @@ function isTapLeafNode(node: TapNode): node is TapLeafNode
 **Example:**
 
 ```typescript
-import { isTapLeafNode } from 'lotus-lib'
+import { isTapLeafNode } from 'lotus-sdk'
 
 const tree = {
   left: { script: script1 },
@@ -3284,7 +3284,7 @@ function isTapBranchNode(node: TapNode): node is TapBranchNode
 **Example:**
 
 ```typescript
-import { isTapBranchNode } from 'lotus-lib'
+import { isTapBranchNode } from 'lotus-sdk'
 
 if (isTapBranchNode(tree)) {
   console.log('This is a branch node')
@@ -3331,7 +3331,7 @@ const internalPubKey = Buffer.concat([
 For manual merkle tree construction:
 
 ```typescript
-import { calculateTapLeaf, calculateTapBranch } from 'lotus-lib'
+import { calculateTapLeaf, calculateTapBranch } from 'lotus-sdk'
 
 // Calculate leaf hashes
 const leaf1 = calculateTapLeaf(script1, 0xc0)
@@ -3356,7 +3356,7 @@ console.log('Merkle root:', root.toString('hex'))
 For advanced scenarios requiring manual key manipulation:
 
 ```typescript
-import { calculateTapTweak, PublicKey, PrivateKey } from 'lotus-lib'
+import { calculateTapTweak, PublicKey, PrivateKey } from 'lotus-sdk'
 
 const privateKey = new PrivateKey()
 const internalPubKey = privateKey.publicKey
@@ -3509,7 +3509,7 @@ import {
   buildMuSigTaprootKey,
   buildMuSigTaprootKeyWithScripts,
   signTaprootKeyPathWithMuSig2,
-} from 'lotus-lib'
+} from 'lotus-sdk'
 
 // CREATE TAPROOT OUTPUT
 const script = buildKeyPathTaproot(publicKey)
@@ -3543,7 +3543,7 @@ const nft = NFT.fromScript(script, metadata, satoshis)
 const transferTx = nft.transfer(newOwner, currentOwner)
 
 // MUSIG2 - High-Level API (Recommended)
-import { MuSig2Signer, createMuSig2Signer } from 'lotus-lib'
+import { MuSig2Signer, createMuSig2Signer } from 'lotus-sdk'
 
 // Create signer
 const signer = new MuSig2Signer({
@@ -3583,7 +3583,7 @@ const taprootSig = signer.completeTaprootSigning(
 )
 
 // MUSIG2 - Session-Based (Advanced)
-import { MuSigSessionManager } from 'lotus-lib'
+import { MuSigSessionManager } from 'lotus-sdk'
 const manager = new MuSigSessionManager()
 const session = manager.createSession(signers, myPrivateKey, message)
 const nonces = manager.generateNonces(session, myPrivateKey)

--- a/examples/bootstrap-persistent-identity-example.ts
+++ b/examples/bootstrap-persistent-identity-example.ts
@@ -64,7 +64,6 @@ async function startBootstrapNode() {
   // Start Zoe as a bootstrap/relay node
   const zoeCoordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/0.0.0.0/tcp/6969'],
-    peerId: zoePeerId, // Persistent identity (same across restarts)
     enableDHT: true,
     enableDHTServer: true, // Full DHT server
     enableRelay: true,
@@ -102,7 +101,6 @@ async function startClientNode(bootstrapAddrs: string[]) {
   // Start Alice with automatic bootstrap connection
   const aliceCoordinator = new MuSig2P2PCoordinator({
     listen: ['/ip4/0.0.0.0/tcp/0'],
-    peerId: alicePeerId, // Persistent identity
     bootstrapPeers: bootstrapAddrs, // 🔥 Automatically connects on startup!
     enableDHT: true,
     enableDHTServer: false, // Client mode

--- a/lib/rpc.ts
+++ b/lib/rpc.ts
@@ -8,7 +8,7 @@ import { RPC as settings } from '../utils/settings.js'
 /**
  * Individual JSON-RPC result types
  */
-export type JSONRPCResult =
+type JSONRPCResult =
   | string
   | string[]
   | number
@@ -22,7 +22,7 @@ export type JSONRPCResult =
 /**
  * Raw JSON-RPC response from the RPC daemon
  */
-export type JSONRPCResponse = {
+type JSONRPCResponse = {
   result: JSONRPCResult
   error: null | {
     code: number
@@ -33,7 +33,7 @@ export type JSONRPCResponse = {
 /**
  * Network information returned by the RPC daemon
  */
-export type NetworkInfo = {
+export interface NetworkInfo {
   /** Subversion string */
   subversion: string
   /** Whether local relay is enabled */
@@ -49,7 +49,7 @@ export type NetworkInfo = {
 /**
  * Mining information returned by the RPC daemon
  */
-export type MiningInfo = {
+export interface MiningInfo {
   /** Current block height */
   blocks: number
   /** Current network difficulty */
@@ -67,7 +67,7 @@ export type MiningInfo = {
 /**
  * Mempool information returned by the RPC daemon
  */
-export type MempoolInfo = {
+export interface MempoolInfo {
   /** Whether the mempool is loaded */
   loaded: boolean
   /** Number of transactions in mempool */
@@ -89,7 +89,7 @@ export type MempoolInfo = {
 /**
  * Peer connection information returned by the RPC daemon
  */
-export type PeerInfo = {
+export interface PeerInfo {
   /** Peer address and port */
   addr: string
   /** Peer services as hex string */
@@ -142,7 +142,7 @@ export type PeerInfo = {
 /**
  * Block statistics returned by the RPC daemon
  */
-export type BlockStats = {
+export interface BlockStats {
   /** Average fee in the block */
   avgfee: number
   /** Average fee rate in the block */
@@ -198,7 +198,7 @@ export type BlockStats = {
 /**
  * Block information returned by the RPC daemon
  */
-export type BlockInfo = {
+export interface BlockInfo {
   /** Block hash */
   hash: string
   /** Number of confirmations */
@@ -224,7 +224,7 @@ export type BlockInfo = {
 /**
  * Transaction input information
  */
-export type TransactionInput = {
+export interface TransactionInput {
   /** Transaction ID */
   txid: string
   /** Output index */
@@ -236,7 +236,7 @@ export type TransactionInput = {
 /**
  * Transaction output information
  */
-export type TransactionOutput = {
+export interface TransactionOutput {
   /** Output value in coins */
   value: number
   /** Script public key information */
@@ -253,7 +253,7 @@ export type TransactionOutput = {
 /**
  * Raw transaction information returned by the RPC daemon
  */
-export type RawTransaction = {
+export interface RawTransaction {
   /** Transaction ID */
   txid: string
   /** Transaction size in bytes */

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "lotus-lib",
-  "version": "0.1.0",
+  "name": "lotus-sdk",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "lotus-lib",
-      "version": "0.1.0",
+      "name": "lotus-sdk",
+      "version": "0.1.1",
       "license": "MIT",
       "dependencies": {
         "@chainsafe/libp2p-noise": "17.0.0",
@@ -45,6 +45,9 @@
         "prettier": "3.6.2",
         "typescript": "5.8.3",
         "typescript-eslint": "8.35.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@achingbrain/nat-port-mapper": {

--- a/package.json
+++ b/package.json
@@ -1,18 +1,32 @@
 {
-  "name": "lotus-lib",
-  "version": "0.1.0",
+  "name": "lotus-sdk",
+  "version": "0.1.1",
   "description": "Central repository for several classes of tools for integrating with, and building for, the Lotusia ecosystem",
-  "main": "index.js",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "type": "module",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
   "directories": {
     "lib": "lib"
   },
   "scripts": {
+    "build": "tsc",
+    "prepublishOnly": "npm run build",
+    "version": "npm run build",
+    "postversion": "git push && git push --tags",
     "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "engines": {
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/LotusiaStewardship/lotus-lib.git"
+    "url": "git+https://github.com/LotusiaStewardship/lotus-sdk.git"
   },
   "keywords": [
     "lotus",
@@ -25,9 +39,9 @@
   "author": "Lotusia Stewardship",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/LotusiaStewardship/lotus-lib/issues"
+    "url": "https://github.com/LotusiaStewardship/lotus-sdk/issues"
   },
-  "homepage": "https://github.com/LotusiaStewardship/lotus-lib#readme",
+  "homepage": "https://github.com/LotusiaStewardship/lotus-sdk#readme",
   "dependencies": {
     "@chainsafe/libp2p-noise": "17.0.0",
     "@libp2p/autonat": "3.0.7",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,32 @@
 {
-  "exclude": ["submodules", "node_modules"],
+  "exclude": [
+    "submodules",
+    "node_modules",
+    "examples",
+    "test",
+    "scripts",
+    "dist",
+    "test.ts",
+    "test.js",
+    "testing.ts",
+    "test-*.ts",
+    "test-*.js",
+    "**/*.test.ts"
+  ],
   "compilerOptions": {
-    "rootDirs": [".", ".output"],
-    "outDir": "./.output",
-    "declaration": false,
+    "rootDir": ".",
+    "outDir": "./dist",
+    "declaration": true,
+    "declarationMap": true,
     "removeComments": true,
     "esModuleInterop": true,
     "allowJs": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": true,
     "module": "Node16",
     "moduleResolution": "node16",
     "target": "ES2022",
-    "lib": ["ES2022", "ES5", "ES6"]
+    "lib": ["ES2023", "DOM"]
   }
 }

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -8,7 +8,7 @@ import type { ScriptChunkPlatformUTF8 } from '../lib/rank/index.js'
 /**
  * API URLs
  */
-export const CHRONIK_API_URL = 'http://172.16.11.102:7123'
+export const CHRONIK_API_URL = 'https://chronik.lotusia.org'
 // export const NODE_API_URL = 'https://explorer.lotusia.org/api'
 export const NODE_GEOIP_URL = 'https://api.sefinek.net/api/v2/geoip'
 export const RANK_API_URL = 'https://rank.lotusia.org/api/v1'


### PR DESCRIPTION
This commit has some minor fixups. Also the package was renamed to `lotus-sdk` from `lotus-lib`, and all documentation has been updated accordingly.

Also, more importantly, the package was fixed up for proper NPM distribution.